### PR TITLE
Fix code-review findings: OOB label indexing, tied-weight merges, load-state safety

### DIFF
--- a/compiler/frontend/forward_builder.cc
+++ b/compiler/frontend/forward_builder.cc
@@ -57,6 +57,16 @@ std::expected<sir::Value*, std::string> BuildForward(
                                  "' inner dimensions disagree (" +
                                  std::to_string(k_x) + " vs " +
                                  std::to_string(k_w) + ")");
+        // The result shape below fixes the row count at `batch`, and the GEMM
+        // lowering sizes its reads from that claim — a left operand with any
+        // other row count (e.g. a constant tensor) would compile into a plan
+        // that reads past the operand's buffer at runtime.
+        const int64_t n_x = (*x)->shape().dims.at(0);
+        if (n_x != batch)
+          return std::unexpected(
+              "UpdateCompiler: MatMul '" + op.name + "' left operand has " +
+              std::to_string(n_x) + " row(s); the update plan is compiled "
+              "for batch " + std::to_string(batch));
         sir::Operation* mm = block.appendOp("sc_high.matmul");
         mm->addOperand(*x);
         mm->addOperand(*w);

--- a/compiler/frontend/sir.cc
+++ b/compiler/frontend/sir.cc
@@ -6,8 +6,23 @@
 #include <algorithm>
 #include <stdexcept>
 #include <cassert>
+#include <cstdio>
+#include <cstdlib>
 
 namespace seecpp::sir {
+
+namespace {
+
+// Structural-invariant violations abort in every build mode: the callers of
+// these APIs (the grafting and autodiff passes) mutate live graphs, and a
+// compiled-out assert would turn a pass bug into silent memory corruption
+// (an increment past end(), a dereference of end()) instead of a diagnosis.
+[[noreturn]] void FatalInvariant(const char* what) {
+    std::fprintf(stderr, "sir: fatal invariant violation: %s\n", what);
+    std::abort();
+}
+
+}  // namespace
 
 // =============================================================================
 // 1. Shape
@@ -195,7 +210,8 @@ void Block::insertOpsAfter(Operation* anchor,
                            std::vector<std::unique_ptr<Operation>> new_ops) {
     auto it = std::find_if(ops_.begin(), ops_.end(),
                            [anchor](const auto& p) { return p.get() == anchor; });
-    assert(it != ops_.end() && "insertOpsAfter: anchor not found in block");
+    if (it == ops_.end())
+        FatalInvariant("insertOpsAfter: anchor not found in block");
 
     for (auto& op : new_ops)
         op->setParentBlock(this);
@@ -207,7 +223,8 @@ void Block::insertOpsAfter(Operation* anchor,
 
 std::unique_ptr<Operation> Block::removeOp(Operation* op) {
     auto it = std::find_if(ops_.begin(), ops_.end(), [op](const auto& p) { return p.get() == op; });
-    assert(it != ops_.end() && "removeOp: operation not found in block");
+    if (it == ops_.end())
+        FatalInvariant("removeOp: operation not found in block");
 
     for (size_t i = 0; i < op->numOperands(); ++i)
         op->operand(i)->removeUser(op);
@@ -266,7 +283,8 @@ Block* Region::addBlock() {
 }
 
 Block* Region::entryBlock() {
-    assert(!blocks_.empty());
+    if (blocks_.empty())
+        FatalInvariant("entryBlock: region has no blocks");
     return blocks_.front().get();
 }
 

--- a/compiler/trainer/update_passes.cc
+++ b/compiler/trainer/update_passes.cc
@@ -54,6 +54,24 @@ std::expected<std::vector<GraftedAdapter>, std::string> LoraGrafter::Run(
   if (targets.empty())
     return std::unexpected("LoraGrafter: no eligible MatMul targets found");
 
+  // A frozen weight multiplied at more than one site (weight tying) would
+  // receive one independent adapter per site, but the merged model has only
+  // one copy of the weight to patch — CommitToModel() would apply one site's
+  // delta and discard the others' training. Until a shared adapter per
+  // frozen weight is supported, reject the graft instead of silently
+  // corrupting the update.
+  {
+    std::unordered_set<const sir::Value*> grafted;
+    for (sir::Operation* target : targets) {
+      const sir::Value* w = target->operand(1);
+      if (!grafted.insert(w).second)
+        return std::unexpected(
+            "LoraGrafter: weight '" + std::string(w->id()) +
+            "' feeds multiple MatMuls (weight tying); tied weights cannot be "
+            "merged site-independently and are not supported");
+    }
+  }
+
   std::vector<GraftedAdapter> adapters;
   const float scale = spec_.alpha / static_cast<float>(spec_.rank);
 

--- a/runtime/update_engine.cc
+++ b/runtime/update_engine.cc
@@ -182,6 +182,21 @@ std::expected<void, std::string> UpdateEngine::LoadFromFile(
 }
 
 std::expected<void, std::string> UpdateEngine::Initialize() {
+  // Unload the previous plan before touching the new one. Every early return
+  // below must leave the engine in the clean "no plan loaded" state — never
+  // half-swapped, with the new header and programs but the previous arena —
+  // or Train() would execute refs validated against the new arena_size over
+  // an allocation of the old size.
+  std::free(arena_);
+  arena_ = nullptr;
+  rodata_ = nullptr;
+  train_program_.clear();
+  merge_program_.clear();
+  emit_table_.clear();
+  num_classes_ = 0;
+  step_ = 0;
+  merged_ = false;
+
   if (plan_size_ < sizeof(up::PlanHeader))
     return std::unexpected("UpdateEngine: plan smaller than its header");
   std::memcpy(&header_, plan_, sizeof(header_));
@@ -261,18 +276,45 @@ std::expected<void, std::string> UpdateEngine::Initialize() {
                header_.arena_size))
     return std::unexpected("UpdateEngine: plan loss slot out of bounds");
 
-  // Class count for validating class-index labels at Train() time (the
-  // softmax kernels index rows of this width with raw dataset labels).
+  // The softmax cross-entropy kernels index probs/dlogits rows with raw
+  // class labels — an out-of-range label is an out-of-bounds read (fwd) or
+  // write (bwd). ValidateInstruction() cannot bound label *values*, so bind
+  // every softmax-xent instruction to the header's label slot and a single
+  // class count here; Train() then validates the dataset's labels against
+  // exactly the buffer and width the kernels will index.
   num_classes_ = 0;
-  for (const up::UpdateInstruction& ins : train_program_)
-    if (static_cast<up::OpCode>(ins.opcode) == up::OpCode::kSoftmaxXEntFwd)
-      num_classes_ = ins.out[1];
+  for (const auto* program : {&train_program_, &merge_program_}) {
+    for (const up::UpdateInstruction& ins : *program) {
+      const auto op = static_cast<up::OpCode>(ins.opcode);
+      if (op != up::OpCode::kSoftmaxXEntFwd &&
+          op != up::OpCode::kSoftmaxXEntBwd)
+        continue;
+      if (header_.label_kind != 1)
+        return std::unexpected(
+            "UpdateEngine: softmax-xent instruction in a plan without "
+            "class-index labels");
+      if (ins.in[1] != header_.label_ref)
+        return std::unexpected(
+            "UpdateEngine: softmax-xent labels are not bound to the plan's "
+            "label slot");
+      // The kernel reads N labels; the feeder writes label_bytes per step.
+      // Labels beyond the feeder's write would be stale or uninitialized.
+      if (ins.out[0] > header_.label_bytes / sizeof(int32_t))
+        return std::unexpected(
+            "UpdateEngine: softmax-xent batch exceeds the plan's label slot");
+      const uint64_t classes = ins.out[1];
+      if (classes == 0 || (num_classes_ != 0 && classes != num_classes_))
+        return std::unexpected(
+            "UpdateEngine: inconsistent class count across softmax-xent "
+            "instructions");
+      num_classes_ = classes;
+    }
+  }
 
   rodata_ = plan_ + header_.rodata_offset;
 
   // The single allocation of the update: the pre-planned arena. Its size was
   // known at compile time — the device's resource contract.
-  std::free(arena_);
   const size_t arena_bytes = (header_.arena_size + 63) & ~size_t{63};
   arena_ = static_cast<uint8_t*>(std::aligned_alloc(64, arena_bytes));
   if (!arena_) return std::unexpected("UpdateEngine: arena allocation failed");

--- a/source/smf.cc
+++ b/source/smf.cc
@@ -1,7 +1,9 @@
 #include "source/smf.h"
 
+#include <algorithm>
 #include <cstring>
 #include <fstream>
+#include <utility>
 
 namespace seeml::update {
 
@@ -141,7 +143,14 @@ std::expected<SmfModel, std::string> LoadSmf(const std::string& path) {
 
   for (uint32_t i = 0; i < num_ops && r.ok; ++i) {
     SmfOp op;
-    op.kind = static_cast<SmfOpKind>(r.Read<uint8_t>());
+    const uint8_t kind = r.Read<uint8_t>();
+    // Range-check the op vocabulary here: ForwardBuilder switches over the
+    // enum, and an out-of-range value would silently skip the op, surfacing
+    // later as a misleading "not a constant tensor" error.
+    if (r.ok && kind > static_cast<uint8_t>(SmfOpKind::kRelu))
+      return std::unexpected("SMF: op " + std::to_string(i) +
+                             " has unknown kind " + std::to_string(kind));
+    op.kind = static_cast<SmfOpKind>(kind);
     op.name = r.ReadStr();
     const uint8_t n_in = r.Read<uint8_t>();
     for (uint8_t k = 0; k < n_in; ++k) op.inputs.push_back(r.ReadStr());
@@ -150,11 +159,53 @@ std::expected<SmfModel, std::string> LoadSmf(const std::string& path) {
   }
 
   if (!r.ok) return std::unexpected("SMF: truncated file '" + path + "'");
+
+  // Each blob was individually range-checked against the file, but the
+  // ranges must also be pairwise disjoint and lie past the metadata (the
+  // writer's layout). Without this, a small file can declare its whole
+  // extent as the data of arbitrarily many tensors, amplifying one crafted
+  // or corrupt megabyte into an unbounded total allocation above.
+  std::vector<std::pair<uint64_t, uint64_t>> ranges;  // (offset, size)
+  for (const auto& t : model.tensors)
+    if (t.is_const) ranges.emplace_back(t.data_offset, t.byte_size);
+  std::sort(ranges.begin(), ranges.end());
+  uint64_t prev_end = r.pos;  // first byte past the metadata section
+  for (const auto& [off, size] : ranges) {
+    if (off < prev_end)
+      return std::unexpected(
+          "SMF: constant tensor data ranges overlap each other or the "
+          "metadata in '" + path + "'");
+    prev_end = off + size;  // cannot wrap: range-checked against file size
+  }
   return model;
 }
 
 std::expected<void, std::string> SaveSmf(const std::string& path,
                                          SmfModel& model) {
+  // The record formats carry u16 string lengths and u8 rank/input counts;
+  // Writer casts silently, so an oversized field would desynchronize every
+  // record after it. Reject instead of writing a self-corrupting file.
+  auto str_ok = [](const std::string& s) { return s.size() <= UINT16_MAX; };
+  if (!str_ok(model.input_name) || !str_ok(model.output_name))
+    return std::unexpected("SMF: I/O tensor name exceeds 65535 bytes");
+  for (const auto& t : model.tensors) {
+    if (!str_ok(t.name))
+      return std::unexpected("SMF: tensor name exceeds 65535 bytes");
+    if (t.dims.size() > UINT8_MAX)
+      return std::unexpected("SMF: tensor '" + t.name + "' rank exceeds 255");
+  }
+  for (const auto& op : model.ops) {
+    if (!str_ok(op.name) || !str_ok(op.output))
+      return std::unexpected("SMF: op name exceeds 65535 bytes");
+    if (op.inputs.size() > UINT8_MAX)
+      return std::unexpected("SMF: op '" + op.name +
+                             "' has more than 255 inputs");
+    for (const auto& in : op.inputs)
+      if (!str_ok(in))
+        return std::unexpected("SMF: op '" + op.name +
+                               "' input name exceeds 65535 bytes");
+  }
+
   // Pass 1: serialize the header/metadata with zeroed data offsets to learn
   // the metadata section size, then lay out the 64-aligned data section.
   auto serialize_meta = [&](Writer& w) {

--- a/test/compiler/forward_builder_test.cc
+++ b/test/compiler/forward_builder_test.cc
@@ -162,6 +162,36 @@ TEST(ForwardBuilder, RejectsInnerDimensionMismatch) {
                         "inner dimensions disagree");
 }
 
+TEST(ForwardBuilder, RejectsConstLhsRowsMismatchingBatch) {
+  SmfModel model;
+  model.input_name = "x";
+  model.output_name = "y";
+  model.tensors.push_back({.name = "x", .dims = {-1, 4}, .is_const = false});
+  model.tensors.push_back(
+      {.name = "a",
+       .dims = {2, 4},
+       .is_const = true,
+       .data = AsBytes({1, 2, 3, 4, 5, 6, 7, 8})});
+  model.tensors.back().byte_size = model.tensors.back().data.size();
+  model.tensors.push_back(
+      {.name = "w",
+       .dims = {4, 3},
+       .is_const = true,
+       .data = AsBytes({1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12})});
+  model.tensors.back().byte_size = model.tensors.back().data.size();
+  // Rank-2 with agreeing inner dims, but the constant LHS has 2 rows while
+  // the plan is compiled for kBatch — the result shape would claim kBatch
+  // rows and the lowered GEMM would read past the 2-row buffer at runtime.
+  model.ops.push_back({SmfOpKind::kMatMul, "mm", {"a", "w"}, "y"});
+
+  sir::Block block;
+  GraphBuild build;
+  build.input = AddInput(block, 4);
+  EXPECT_ERROR_CONTAINS(
+      BuildForward(block, model, "", build.input, kBatch, build),
+      "compiled for batch");
+}
+
 TEST(ForwardBuilder, RejectsBiasWidthMismatch) {
   SmfModel model;
   model.input_name = "x";

--- a/test/compiler/update_compiler_test.cc
+++ b/test/compiler/update_compiler_test.cc
@@ -130,25 +130,16 @@ TEST(UpdateCompiler, CompilationIsDeterministic) {
   EXPECT_TRUE(a.plan == b.plan);
 }
 
-TEST(UpdateCompiler, TiedWeightMaterializesOnce) {
+TEST(UpdateCompiler, RejectsTiedWeights) {
   SmfModel model = MakeTiedMlp(4, 4);
   UpdateConfig config = BaseConfig(kBatch);
-  ASSERT_OK_AND_ASSIGN(CompiledUpdate compiled,
-                       UpdateCompiler(config).Compile(model));
 
-  // The tied tensor resolves to a single SIR value: each consuming MatMul
-  // still gets its own adapter, but both share one frozen rodata copy and
-  // their emit entries patch the same source byte range.
-  const PlanHeader h = HeaderOf(compiled);
-  ASSERT_EQ(compiled.adapters.size(), 2u);
-  EXPECT_EQ(compiled.adapters[0].weight_rodata_ref,
-            compiled.adapters[1].weight_rodata_ref);
-  ASSERT_EQ(h.emit_count, 2u);
-  std::vector<EmitEntry> emits(h.emit_count);
-  std::memcpy(emits.data(), compiled.plan.data() + h.emit_table_offset,
-              h.emit_count * sizeof(EmitEntry));
-  EXPECT_EQ(emits[0].smf_data_offset, emits[1].smf_data_offset);
-  EXPECT_EQ(emits[0].byte_size, emits[1].byte_size);
+  // A tied weight would receive one independent adapter per consuming
+  // MatMul, but the merged model holds a single copy of the weight — the
+  // commit would patch its byte range once per adapter, keeping one site's
+  // delta and silently discarding the others'. The graft refuses instead.
+  EXPECT_ERROR_CONTAINS(UpdateCompiler(config).Compile(model),
+                        "weight tying");
 }
 
 TEST(UpdateCompiler, MseLossUsesDenseLabels) {

--- a/test/compiler/update_passes_test.cc
+++ b/test/compiler/update_passes_test.cc
@@ -141,6 +141,18 @@ TEST(LoraGrafter, RejectsNonPositiveRank) {
                         "rank must be positive");
 }
 
+TEST(LoraGrafter, RejectsTiedFrozenWeight) {
+  sir::Block block;
+  GraphBuild build;
+  SmfModel model = seeml::testing::MakeTiedMlp(4, 1);
+  build.input = block.addArgument(sir::DataType::F32, sir::Shape{kBatch, 4});
+  ASSERT_OK(BuildForward(block, model, "", build.input, kBatch, build));
+
+  // Both MatMuls multiply the same frozen weight Value; per-site adapters
+  // cannot be merged back into the single on-disk copy.
+  EXPECT_ERROR_CONTAINS(LoraGrafter(Spec()).Run(block), "weight tying");
+}
+
 TEST(LoraGrafter, RejectsWhenNoTargetMatches) {
   sir::Block block;
   GraphBuild build;

--- a/test/runtime/update_engine_test.cc
+++ b/test/runtime/update_engine_test.cc
@@ -57,6 +57,18 @@ TrainOptions Quiet() {
   return options;
 }
 
+/// Byte offset of the first train instruction with `oc`, or 0 if absent.
+size_t FindTrainInstr(const std::vector<uint8_t>& plan, OpCode oc) {
+  const PlanHeader h = HeaderOf(plan);
+  for (uint64_t i = 0; i < h.train_instr_count; ++i) {
+    const size_t off = h.train_instr_offset + i * sizeof(UpdateInstruction);
+    UpdateInstruction ins;
+    std::memcpy(&ins, plan.data() + off, sizeof(ins));
+    if (ins.opcode == static_cast<uint16_t>(oc)) return off;
+  }
+  return 0;
+}
+
 TEST(UpdateEngineLoad, AcceptsCompiledPlan) {
   const std::vector<uint8_t> plan = CompilePlan(BaseConfig(kBatch));
   ASSERT_FALSE(plan.empty());
@@ -147,6 +159,80 @@ TEST(UpdateEngineLoad, RejectsOperandOutsideItsAddressSpace) {
   UpdateEngine engine;
   EXPECT_ERROR_CONTAINS(engine.LoadFromMemory(plan.data(), plan.size()),
                         "out of bounds");
+}
+
+TEST(UpdateEngineLoad, FailedReloadLeavesEngineUnloaded) {
+  const std::vector<uint8_t> good = CompilePlan(BaseConfig(kBatch));
+  ASSERT_FALSE(good.empty());
+  UpdateEngine engine;
+  ASSERT_OK(engine.LoadFromMemory(good.data(), good.size()));
+
+  // A plan that fails validation *late* in the load — after its header and
+  // programs have been decoded.
+  std::vector<uint8_t> bad = good;
+  const PlanHeader h = HeaderOf(bad);
+  UpdateInstruction ins;
+  std::memcpy(&ins, bad.data() + h.train_instr_offset, sizeof(ins));
+  ins.in[0] = MakeArenaRef(h.arena_size + (1ULL << 32));
+  std::memcpy(bad.data() + h.train_instr_offset, &ins, sizeof(ins));
+  EXPECT_ERROR(engine.LoadFromMemory(bad.data(), bad.size()));
+
+  // The failed load must not leave the bad plan's programs paired with the
+  // good plan's arena; the engine must be cleanly unloaded.
+  ASSERT_OK_AND_ASSIGN(Dataset data, MakeClassificationData(32, kInDim, 1));
+  EXPECT_ERROR_CONTAINS(engine.Train(data, 1, Quiet()), "no plan loaded");
+  EXPECT_ERROR_CONTAINS(engine.RunMerge(), "no plan loaded");
+}
+
+TEST(UpdateEngineLoad, RejectsSoftmaxLabelsUnboundFromLabelSlot) {
+  std::vector<uint8_t> plan = CompilePlan(BaseConfig(kBatch));
+  ASSERT_FALSE(plan.empty());
+  const PlanHeader h = HeaderOf(plan);
+  const size_t off = FindTrainInstr(plan, OpCode::kSoftmaxXEntFwd);
+  ASSERT_NE(off, 0u);
+
+  // Point the labels operand at a different (individually valid) arena
+  // region: the input slot. The kernel would then index probs rows with
+  // whatever bit patterns live there — an unbounded read/write.
+  UpdateInstruction ins;
+  std::memcpy(&ins, plan.data() + off, sizeof(ins));
+  ins.in[1] = MakeArenaRef(RefOffset(h.input_ref));
+  std::memcpy(plan.data() + off, &ins, sizeof(ins));
+
+  UpdateEngine engine;
+  EXPECT_ERROR_CONTAINS(engine.LoadFromMemory(plan.data(), plan.size()),
+                        "not bound to the plan's label slot");
+}
+
+TEST(UpdateEngineLoad, RejectsInconsistentSoftmaxClassCounts) {
+  std::vector<uint8_t> plan = CompilePlan(BaseConfig(kBatch));
+  ASSERT_FALSE(plan.empty());
+  const size_t off = FindTrainInstr(plan, OpCode::kSoftmaxXEntBwd);
+  ASSERT_NE(off, 0u);
+
+  // Shrink the backward instruction's class count: labels validated against
+  // the forward's C would still index out of the backward's narrower rows.
+  UpdateInstruction ins;
+  std::memcpy(&ins, plan.data() + off, sizeof(ins));
+  ASSERT_GT(ins.out[1], 1u);
+  ins.out[1] -= 1;
+  std::memcpy(plan.data() + off, &ins, sizeof(ins));
+
+  UpdateEngine engine;
+  EXPECT_ERROR_CONTAINS(engine.LoadFromMemory(plan.data(), plan.size()),
+                        "inconsistent class count");
+}
+
+TEST(UpdateEngineLoad, RejectsSoftmaxWithoutClassLabels) {
+  std::vector<uint8_t> plan = CompilePlan(BaseConfig(kBatch));
+  ASSERT_FALSE(plan.empty());
+  PlanHeader h = HeaderOf(plan);
+  h.label_kind = 2;  // dense targets: ValidateClassLabels() would never run
+  PutHeader(plan, h);
+
+  UpdateEngine engine;
+  EXPECT_ERROR_CONTAINS(engine.LoadFromMemory(plan.data(), plan.size()),
+                        "without class-index labels");
 }
 
 TEST(UpdateEngineLoad, LoadFromFileMatchesLoadFromMemory) {

--- a/test/source/smf_test.cc
+++ b/test/source/smf_test.cc
@@ -3,7 +3,9 @@
 // rejection of malformed files (the binary-format hardening surface).
 // =============================================================================
 
+#include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -192,6 +194,73 @@ TEST(Smf, LoadRejectsInvalidDims) {
       {.name = "w", .dims = {}, .is_const = true, .data = AsBytes({1.0f})});
   ASSERT_OK(SaveSmf(path, rank0));
   EXPECT_ERROR_CONTAINS(LoadSmf(path), "invalid dims");
+}
+
+TEST(Smf, LoadRejectsOverlappingDataRanges) {
+  ScopedTempDir dir;
+  SmfModel model = MakeMlp(4, 8, 2, 1);
+  const std::string path = dir.File("model.smf");
+  ASSERT_OK(SaveSmf(path, model));
+  ASSERT_OK_AND_ASSIGN(SmfModel saved, LoadSmf(path));
+  const SmfTensor* w1 = saved.FindTensor("w1");
+  const SmfTensor* b1 = saved.FindTensor("b1");
+  ASSERT_NE(w1, nullptr);
+  ASSERT_NE(b1, nullptr);
+
+  // Patch b1's metadata offset field to alias w1's blob. Both ranges stay
+  // individually inside the file, so only the disjointness check can fire.
+  // The field is the first occurrence of b1's offset below the data section.
+  std::vector<uint8_t> bytes = ReadAll(path);
+  uint64_t data_start = bytes.size();
+  for (const auto& t : saved.tensors)
+    if (t.is_const) data_start = std::min(data_start, t.data_offset);
+  const auto* needle = reinterpret_cast<const uint8_t*>(&b1->data_offset);
+  auto it = std::search(bytes.begin(),
+                        bytes.begin() + static_cast<ptrdiff_t>(data_start),
+                        needle, needle + sizeof(uint64_t));
+  ASSERT_TRUE(it != bytes.begin() + static_cast<ptrdiff_t>(data_start));
+  std::memcpy(&*it, &w1->data_offset, sizeof(uint64_t));
+  WriteAll(path, bytes);
+
+  EXPECT_ERROR_CONTAINS(LoadSmf(path), "overlap");
+}
+
+TEST(Smf, LoadRejectsUnknownOpKind) {
+  ScopedTempDir dir;
+  SmfModel model = MakeMlp(4, 8, 2, 1);
+  const std::string path = dir.File("model.smf");
+  ASSERT_OK(SaveSmf(path, model));
+
+  // An op record is: kind u8, then the u16-length-prefixed name. Locate op
+  // "mm1" by its length-prefixed name; the byte before the prefix is the kind.
+  std::vector<uint8_t> bytes = ReadAll(path);
+  const uint8_t needle[] = {3, 0, 'm', 'm', '1'};
+  auto it = std::search(bytes.begin(), bytes.end(), needle,
+                        needle + sizeof(needle));
+  ASSERT_TRUE(it != bytes.end());
+  *(it - 1) = 200;
+  WriteAll(path, bytes);
+
+  EXPECT_ERROR_CONTAINS(LoadSmf(path), "unknown kind");
+}
+
+TEST(Smf, SaveRejectsOversizedMetadata) {
+  ScopedTempDir dir;
+  const std::string path = dir.File("model.smf");
+
+  // The formats carry u16 string lengths and u8 rank/input counts; a silent
+  // cast would desynchronize every record after the oversized field.
+  SmfModel long_name = MakeMlp(4, 8, 2, 1);
+  long_name.tensors[1].name.assign(70000, 'n');
+  EXPECT_ERROR_CONTAINS(SaveSmf(path, long_name), "65535");
+
+  SmfModel deep_rank = MakeMlp(4, 8, 2, 1);
+  deep_rank.tensors[1].dims.assign(300, 1);
+  EXPECT_ERROR_CONTAINS(SaveSmf(path, deep_rank), "rank exceeds 255");
+
+  SmfModel wide_op = MakeMlp(4, 8, 2, 1);
+  wide_op.ops[0].inputs.assign(300, "x");
+  EXPECT_ERROR_CONTAINS(SaveSmf(path, wide_op), "more than 255 inputs");
 }
 
 TEST(Smf, SaveRejectsConstantTensorWithoutData) {


### PR DESCRIPTION
Fixes the correctness and memory-safety findings from the codebase review tracked in #2. Every fix ships with a regression test in the corresponding SeeTest suite; all ten suites pass under `-std=c++23 -O2 -Wall -Wextra -Werror`.

## Fixes

| Severity | Component | Finding |
|---|---|---|
| Critical | `runtime/update_engine.cc` | Softmax-xent kernels index `probs`/`dlogits` rows with raw class labels. A plan could pass every existing validation check while pointing the label operand at any arena region (e.g. float activations, whose int32 bit patterns reach ±2³¹) — an out-of-bounds **write** in the backward kernel. Load-time validation now binds every softmax-xent instruction to the header's label slot, one consistent class count, and `label_kind == 1`, so `ValidateClassLabels()` covers exactly the buffer and width the kernels index. |
| Major | `runtime/update_engine.cc` | A failed `Initialize()` left the new plan's decoded programs paired with the previous plan's arena; the next `Train()` executed refs validated against the new arena size over the old allocation. Any failure now leaves the engine cleanly unloaded. |
| Major | `compiler/trainer/update_passes.cc` | Tied (multiply-used) frozen weights received one independent adapter per use site, but `CommitToModel()` patches the weight's single byte range once per adapter — one site's trained delta silently overwrote the others'. The graft now rejects tied weights with a clear error. **Note:** this replaces `UpdateCompiler.TiedWeightMaterializesOnce`, which codified the double-patch layout as intended; that layout is unrepresentable-correctly at commit time. Proper shared-adapter support is post-freeze feature work. |
| Major | `compiler/frontend/forward_builder.cc` | MatMul results hardcoded `batch` rows without checking the LHS row count; a well-formed SMF with a constant LHS compiled into a plan whose GEMM reads past the operand's buffer at runtime. Now a compile error. |
| Major | `compiler/frontend/sir.cc` | `insertOpsAfter` / `removeOp` / `entryBlock` guarded structural invariants with `assert` only — compiled out under NDEBUG, turning pass bugs into silent memory corruption (increment past `end()`, deref of `end()`). Violations now abort with a diagnostic in all build modes. |
| Major | `source/smf.cc` | Constant-tensor data ranges were individually range-checked but could overlap: a crafted/corrupt ~10 MB file could declare its whole extent as the data of ~350k tensors, amplifying into terabytes of allocations (OOM kill). Ranges must now be pairwise disjoint and follow the metadata. |
| Minor | `source/smf.cc` | Unknown op kinds are rejected at load (previously silently skipped by ForwardBuilder's switch, surfacing as a misleading error later). `SaveSmf` returns errors for names > 65535 bytes, rank > 255, and op inputs > 255 instead of silently truncating length prefixes and writing a self-corrupting file. |

## Regression tests

- `UpdateEngineLoad.RejectsSoftmaxLabelsUnboundFromLabelSlot`, `.RejectsInconsistentSoftmaxClassCounts`, `.RejectsSoftmaxWithoutClassLabels`, `.FailedReloadLeavesEngineUnloaded`
- `LoraGrafter.RejectsTiedFrozenWeight`, `UpdateCompiler.RejectsTiedWeights`
- `ForwardBuilder.RejectsConstLhsRowsMismatchingBatch`
- `Smf.LoadRejectsOverlappingDataRanges`, `.LoadRejectsUnknownOpKind`, `.SaveRejectsOversizedMetadata`

## Scope and freeze compliance

Per the #2 directive, no features, structural mutations, or optimization passes — every `source`/`compiler`/`runtime` change is a validation guard or error path serving the freeze's stated goal (mathematical correctness and system safety), and the bulk of the diff is `test/`.

## Coordination note

A concurrent working tree carries uncommitted v2 work that rewrites `runtime/update_engine.cc` heavily (and touches `update_passes.cc`/`forward_builder.cc`). These findings are live in **both** trees; the fixes here were chosen to be minimal, but expect a textual conflict in `update_engine.cc` when the v2 work lands — the label-binding and reset-on-failure logic should carry over to the v2 `Initialize()` largely as-is.

Remaining review findings that are *already fixed* in the uncommitted v2 tree (plan-hash verification, v2 opcode validation, LR schedule, checkpoint staging, fsync durability, strict CLI parsing) are intentionally not duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
