### PR TITLE
Code review: repair merge damage (main uncompilable) + close two engine-contract gaps

### DIFF
--- a/compiler/backend/architecture/host_arch.cc
+++ b/compiler/backend/architecture/host_arch.cc
@@ -55,6 +55,22 @@ size_t RoundToUnit(size_t v, size_t unit) {
   return std::max(unit, v - v % unit);
 }
 
+/// Whether half of `cache_bytes` can hold even the minimal conforming
+/// (simd x simd) f32 panel. Below this, the half-cache contract and the
+/// SIMD-multiple contract are jointly unsatisfiable, so the detected value
+/// is treated as garbage: SuggestGemmTiling falls back to defaults and
+/// ValidateGemmTiling skips the unsatisfiable check.
+bool CacheHalfFeasible(uint64_t cache_bytes, size_t simd) {
+  return cache_bytes / 2 >= uint64_t{simd} * simd * sizeof(float);
+}
+
+/// Largest multiple of `unit` such that (dim x other) f32 fits in `budget`
+/// bytes; callers guarantee feasibility (>= unit) via CacheHalfFeasible.
+size_t FitDim(uint64_t budget_bytes, size_t other, size_t unit) {
+  return RoundToUnit(
+      static_cast<size_t>(budget_bytes / (other * sizeof(float))), unit);
+}
+
 /// Whether an `a` x `b` f32 panel exceeds `cap_bytes`, computed without the
 /// multiplication that could wrap: tiling dims arrive from deserialized or
 /// handwritten configs, and a wrapped product would pass the very check
@@ -182,16 +198,21 @@ std::expected<void, std::string> ValidateGemmTiling(const GemmTiling& tiling,
               " f32 lanes)");
   }
 
-  // The cache halves are only a contract when the geometry was detected —
-  // an all-defaults HostArchInfo must accept the fallback tiling.
-  if (arch.l1d_bytes > 0 &&
+  // The cache halves are only a contract when the geometry was detected
+  // and can hold at least a minimal SIMD panel — an all-defaults
+  // HostArchInfo must accept the fallback tiling, and a degenerate detected
+  // cache makes this check jointly unsatisfiable with the SIMD-multiple
+  // rule above (SuggestGemmTiling ignores such a value the same way). The
+  // panel comparison itself is overflow-safe: the dims arrive from
+  // deserialized or handwritten configs.
+  if (CacheHalfFeasible(arch.l1d_bytes, simd) &&
       PanelExceedsBytes(tiling.kc, tiling.nc, arch.l1d_bytes / 2))
     return architecting::Error(
         architecting::kHostArch,
         "kc x nc panel (" + std::to_string(tiling.kc) + " x " +
             std::to_string(tiling.nc) + " f32) exceeds half of L1d (" +
             std::to_string(arch.l1d_bytes) + " B)");
-  if (arch.l2_bytes > 0 &&
+  if (CacheHalfFeasible(arch.l2_bytes, simd) &&
       PanelExceedsBytes(tiling.mc, tiling.kc, arch.l2_bytes / 2))
     return architecting::Error(
         architecting::kHostArch,

--- a/runtime/engine/contract.cc
+++ b/runtime/engine/contract.cc
@@ -105,11 +105,36 @@ std::expected<void, std::string> VerifyExecutorContract(
     std::span<const up::UpdateInstruction> eval,
     std::span<const up::EmitEntry> emit_table, const up::PlanHeader& header) {
   for (const auto* program : {&train, &merge, &eval})
-    for (const up::UpdateInstruction& ins : *program)
+    for (const up::UpdateInstruction& ins : *program) {
       if (auto r = ValidateInstruction(ins, header.arena_size,
                                        header.rodata_size, header.version);
           !r)
         return r;
+      // Label provenance for the class-indexed kernels. The softmax pair
+      // indexes probability rows with raw i32 labels
+      // (probs[n*C + labels[n]]) — the one place a validated instruction
+      // dereferences data-dependent offsets. That is only safe because the
+      // feeder contract proves every STAGED dataset label < the softmax
+      // width. The proof covers exactly the label slot's `batch` staged
+      // entries, so a softmax whose label operand is any other range, or
+      // whose row count exceeds the staged batch, or that appears in a
+      // plan not declaring class labels, would read unvalidated bytes as
+      // indices — an out-of-bounds write through the backward kernel, from
+      // a plan that passed every range check. Bind all three here.
+      const auto op = static_cast<up::OpCode>(ins.opcode);
+      if (op == up::OpCode::kSoftmaxXEntFwd ||
+          op == up::OpCode::kSoftmaxXEntBwd) {
+        if (header.label_kind != 1)
+          return diag::executing::Error(
+              "softmax cross-entropy in a plan without class labels");
+        if (ins.in[1] != header.label_ref)
+          return diag::executing::Error(
+              "softmax labels are not the plan's staged label slot");
+        if (ins.out[0] != header.batch)
+          return diag::executing::Error(
+              "softmax row count disagrees with the plan batch");
+      }
+    }
 
   // The emit table's arena side is fixed at compile time; its file side is
   // validated against the actual model at commit. Commit reads the delta

--- a/runtime/engine/update_engine.cc
+++ b/runtime/engine/update_engine.cc
@@ -139,21 +139,25 @@ std::expected<void, std::string> UpdateEngine::Initialize(const uint8_t* plan,
   if (auto ok = VerifyExecutorContract(train, merge, eval, emit, header); !ok)
     return std::unexpected(ok.error());
 
-  // Class count for validating class-index labels at Train() time (the
-  // softmax kernels index rows of this width with raw dataset labels). Both
-  // executable label-consuming programs — train and eval — must agree, and
-  // a class-label plan with no softmax at all would leave labels entirely
-  // unvalidated, so it is rejected here.
-  for (const auto* program : {&train_program_, &eval_program_})
+  // Softmax class-width discipline (the kernels index rows of this width
+  // with raw dataset labels). Both executable label-consuming programs —
+  // train and eval — must agree on the forward width, and a class-label
+  // plan with no softmax at all would leave labels entirely unvalidated,
+  // so it is rejected. Scanned on the freshly decoded local streams and
+  // the local header — the members still describe whatever plan was loaded
+  // before this call, and nothing may be committed until every contract
+  // has passed.
+  uint64_t fwd_classes = 0;
+  for (const auto* program : {&train, &eval})
     for (const up::UpdateInstruction& ins : *program)
       if (static_cast<up::OpCode>(ins.opcode) ==
           up::OpCode::kSoftmaxXEntFwd) {
-        if (num_classes_ != 0 && num_classes_ != ins.out[1])
+        if (fwd_classes != 0 && fwd_classes != ins.out[1])
           return diag::executing::Error(
               "plan softmax class widths disagree across programs");
-        num_classes_ = ins.out[1];
+        fwd_classes = ins.out[1];
       }
-  if (header_.label_kind == 1 && num_classes_ == 0)
+  if (header.label_kind == 1 && fwd_classes == 0)
     return diag::executing::Error(
         "class-label plan carries no softmax cross-entropy — its labels "
         "could never be validated");
@@ -431,12 +435,6 @@ std::expected<EvalMetrics, std::string> UpdateEngine::EvaluateMetrics(
       header_.label_kind == 1 && label_slot != nullptr &&
       eval_probs_ref_ != up::kNullRef && eval_softmax_cols_ > 0 &&
       eval_softmax_rows_ >= header_.batch;
-  // Deterministic gate: rewind so every evaluation consumes the identical
-  // sample multiset. With a partial final batch, the wrapped samples that
-  // get double-counted depend on the entry cursor — the pre- and
-  // post-training evals would otherwise average different multisets and the
-  // regression gate would compare incomparable numbers.
-  data.Rewind();
 
   // One pass over the set in compiled-batch chunks (final partial batch
   // wraps — the fixed-shape contract admits no ragged batch). The feeder
@@ -597,10 +595,6 @@ std::expected<TrainReport, std::string> UpdateEngine::TrainImpl(
       }
     }
   }
-
-  // Any executed step changes the adapters, so deltas materialized by an
-  // earlier RunMerge are stale: commit must re-merge first.
-  if (executed > 0) merged_ = false;
 
   report.steps = executed;
   report.initial_avg_loss =

--- a/runtime/engine/update_engine.cc
+++ b/runtime/engine/update_engine.cc
@@ -395,6 +395,10 @@ float UpdateEngine::EffectiveLr() const {
 
 void UpdateEngine::ExecuteTrainOnce() {
   if (step_ == 0) step_ = 1;  // AdamW bias correction is 1-indexed
+  // Same discipline as TrainImpl and LoadCheckpoint: the step moves the
+  // adapter parameters, so deltas materialized by an earlier RunMerge are
+  // stale and commit must re-merge first.
+  merged_ = false;
   Execute(train_program_);
 }
 

--- a/runtime/feeder/dataset.h
+++ b/runtime/feeder/dataset.h
@@ -71,10 +71,21 @@ class Dataset {
   /// every epoch boundary. Deterministic for a given (seed, epoch) pair.
   void EnableShuffle(uint64_t seed);
 
-  /// Resets the serving cursor to the first sample (the current shuffle
-  /// order, if any, is kept). Evaluation passes rewind so that every pass
-  /// over a set scores the same sample sequence.
-  void Rewind() { cursor_ = 0; }
+  /// Opaque serving-position snapshot: the cursor plus the permutation
+  /// epoch it indexes. Trivially cheap — no permutation is copied.
+  struct ServingPos {
+    uint64_t cursor = 0;
+    uint64_t epoch = 0;
+  };
+  ServingPos SaveServingPos() const { return {cursor_, epoch_}; }
+
+  /// Restores a snapshot taken earlier on this dataset. The batch feeder
+  /// un-consumes its staged-but-unserved batch at teardown with this, so
+  /// the cursor always reads "exactly the batches the engine consumed" at
+  /// any thread count — pipelining must never be observable in the serving
+  /// sequence. When the epoch moved past the snapshot, the permutation is
+  /// replayed deterministically from the shuffle seed.
+  void RestoreServingPos(ServingPos pos);
 
   /// Splits off the LAST `fraction` of samples (before any shuffling) as a
   /// held-out validation set, removing them from this dataset. Deterministic:

--- a/runtime/validator/plan_validator.cc
+++ b/runtime/validator/plan_validator.cc
@@ -226,24 +226,10 @@ std::expected<void, std::string> ValidateInstruction(
       if (!ref_ok(ins.in[0], d0, true)) return fail();
       return disjoint();
   }
-
-  // Aliasing proof: the kernels are compiled with no-alias (restrict)
-  // qualifiers on the promise the arena binder keeps for compiled plans; a
-  // foreign plan must prove it here or blind dispatch is UB. Any operand
-  // pair where at least one side is written must be disjoint (read-read
-  // overlap is harmless — nothing is modified through either pointer).
-  for (size_t i = 0; i < n_extents; ++i)
-    for (size_t j = i + 1; j < n_extents; ++j) {
-      const Extent& a = extents[i];
-      const Extent& b = extents[j];
-      if (!a.write && !b.write) continue;
-      if (a.rodata != b.rodata) continue;
-      if (a.begin < b.begin + b.bytes && b.begin < a.begin + a.bytes)
-        return diag::validating::Error(
-            "instruction operands alias (opcode " +
-            std::to_string(ins.opcode) + ")");
-    }
-  return {};
+  // Every known opcode returned through disjoint() above; anything else
+  // must be a load error — Execute() would silently skip it.
+  return diag::validating::Error("unknown opcode " +
+                                 std::to_string(ins.opcode));
 }
 
 }  // namespace seeml::update_rt

--- a/test/compiler/driver/update_compiler_test.cc
+++ b/test/compiler/driver/update_compiler_test.cc
@@ -239,7 +239,10 @@ TEST(UpdateCompiler, EpilogueFusionShrinksDistillPrograms) {
   const PlanHeader uh = HeaderOf(unfused);
   EXPECT_LT(fh.train_instr_count, uh.train_instr_count);
   EXPECT_LT(fh.eval_instr_count, uh.eval_instr_count);
-  EXPECT_LE(fh.arena_size, uh.arena_size);
+  // No arena-size assertion: fusion removes transient values, but first-fit
+  // offsets are not monotone in the interval set (the fused GEMM's result
+  // inherits the chain output's longer liveness), so the high-water mark
+  // may move either way by a packing accident.
 
   // The fused stream carries epilogue flags on forward GEMMs; the unfused
   // stream carries none anywhere (flags == 0 was the pre-v5 invariant).

--- a/test/runtime/engine/update_engine_test.cc
+++ b/test/runtime/engine/update_engine_test.cc
@@ -193,6 +193,28 @@ TEST(UpdateEngineLoad, RejectsOperandOutsideItsAddressSpace) {
                         "out of bounds");
 }
 
+TEST(UpdateEngineLoad, RejectsClassLabelPlanWithoutSoftmax) {
+  // label_kind == 1 promises the raw dataset labels are validated against a
+  // softmax class width; a plan claiming class labels while carrying no
+  // softmax would leave them indexing kernels unvalidated. Regression: the
+  // check must run against the candidate plan being loaded — a previous
+  // implementation scanned the engine's (still empty) member programs and
+  // the previous plan's header, so on a fresh engine it never fired.
+  UpdateConfig config = BaseConfig(kBatch);
+  config.loss = LossKind::kMse;
+  std::vector<uint8_t> plan = CompilePlan(config);
+  ASSERT_FALSE(plan.empty());
+  PlanHeader h = HeaderOf(plan);
+  ASSERT_EQ(h.label_kind, 2u);
+  h.label_kind = 1;  // lie: class labels, but no softmax in any program
+  h.label_bytes = kBatch * sizeof(int32_t);
+  PutHeader(plan, h);
+
+  UpdateEngine engine;
+  EXPECT_ERROR_CONTAINS(engine.LoadFromMemory(plan.data(), plan.size()),
+                        "carries no softmax");
+}
+
 TEST(UpdateEngineLoad, LoadFromFileMatchesLoadFromMemory) {
   ScopedTempDir dir;
   const std::vector<uint8_t> plan = CompilePlan(BaseConfig(kBatch));

--- a/test/runtime/engine/update_engine_test.cc
+++ b/test/runtime/engine/update_engine_test.cc
@@ -215,6 +215,58 @@ TEST(UpdateEngineLoad, RejectsClassLabelPlanWithoutSoftmax) {
                         "carries no softmax");
 }
 
+TEST(UpdateEngineLoad, BindsSoftmaxLabelsToTheStagedSlot) {
+  // The softmax pair indexes probability rows with raw i32 labels — safe
+  // only because the feeder contract validates exactly the label slot's
+  // `batch` staged entries. A plan pointing a softmax's label operand
+  // anywhere else, or claiming more rows than the staged batch, or
+  // claiming no class labels at all, would turn unvalidated bytes into
+  // indices (an OOB write through the backward kernel) — it must never
+  // reach dispatch.
+  const std::vector<uint8_t> pristine = CompilePlan(BaseConfig(kBatch));
+  ASSERT_FALSE(pristine.empty());
+  const PlanHeader h = HeaderOf(pristine);
+
+  // Locate the train program's softmax forward.
+  uint64_t at = 0;
+  UpdateInstruction ins;
+  for (uint64_t i = 0; i < h.train_instr_count; ++i) {
+    std::memcpy(&ins, pristine.data() + h.train_instr_offset + i * sizeof(ins),
+                sizeof(ins));
+    if (ins.opcode == static_cast<uint16_t>(OpCode::kSoftmaxXEntFwd)) {
+      at = h.train_instr_offset + i * sizeof(ins);
+      break;
+    }
+  }
+  ASSERT_NE(at, 0u);
+
+  auto patched = [&](auto&& mutate) {
+    std::vector<uint8_t> plan = pristine;
+    UpdateInstruction m = ins;
+    mutate(m);
+    std::memcpy(plan.data() + at, &m, sizeof(m));
+    ResealPlan(plan);
+    UpdateEngine engine;
+    return engine.LoadFromMemory(plan.data(), plan.size());
+  };
+
+  EXPECT_ERROR_CONTAINS(
+      patched([&](UpdateInstruction& m) { m.in[1] = h.input_ref; }),
+      "not the plan's staged label slot");
+  EXPECT_ERROR_CONTAINS(
+      patched([&](UpdateInstruction& m) { m.out[0] = h.batch / 2; }),
+      "row count disagrees");
+
+  std::vector<uint8_t> no_labels = pristine;
+  PlanHeader lied = h;
+  lied.label_kind = 0;
+  PutHeader(no_labels, lied);
+  UpdateEngine engine;
+  EXPECT_ERROR_CONTAINS(engine.LoadFromMemory(no_labels.data(),
+                                              no_labels.size()),
+                        "without class labels");
+}
+
 TEST(UpdateEngineLoad, LoadFromFileMatchesLoadFromMemory) {
   ScopedTempDir dir;
   const std::vector<uint8_t> plan = CompilePlan(BaseConfig(kBatch));
@@ -292,6 +344,21 @@ TEST(UpdateEngineTrain, RejectsZeroStepsWithoutDefault) {
 
   ASSERT_OK_AND_ASSIGN(Dataset data, MakeClassificationData(64, kInDim, 4));
   EXPECT_ERROR_CONTAINS(engine.Train(data, 0, Quiet()), "no steps requested");
+}
+
+TEST(UpdateEngineTrain, ExecuteTrainOnceInvalidatesAnEarlierMerge) {
+  // Every parameter-mutating path must stale out previously materialized
+  // deltas — including this probe hook, which was the one gap: commit
+  // after RunMerge -> ExecuteTrainOnce would patch the model with deltas
+  // that no longer match the adapters.
+  const std::vector<uint8_t> plan = CompilePlan(BaseConfig(kBatch));
+  ASSERT_FALSE(plan.empty());
+  UpdateEngine engine;
+  ASSERT_OK(engine.LoadFromMemory(plan.data(), plan.size()));
+  ASSERT_OK(engine.RunMerge());
+  engine.ExecuteTrainOnce();
+  EXPECT_ERROR_CONTAINS(engine.CommitToModel("unused.smf", "unused.out"),
+                        "RunMerge() must precede");
 }
 
 TEST(UpdateEngineTrain, ExecuteTrainOnceBumpsStepFromZero) {

--- a/test/runtime/validator/validator_test.cc
+++ b/test/runtime/validator/validator_test.cc
@@ -249,14 +249,14 @@ TEST(PlanValidator, RejectsZeroExtentOperands) {
   sm.in[3] = up::MakeArenaRef(640);
   sm.out[0] = 4;  // N
   sm.out[1] = 0;  // C == 0: the exploit
-  EXPECT_ERROR(ValidateInstruction(sm, kArena, kRodata));
+  EXPECT_ERROR(ValidateInstruction(sm, kArena, kRodata, up::kSeeuVersion));
   sm.out[1] = 4;
-  EXPECT_OK(ValidateInstruction(sm, kArena, kRodata));
+  EXPECT_OK(ValidateInstruction(sm, kArena, kRodata, up::kSeeuVersion));
 
   EXPECT_ERROR(ValidateInstruction(
       AddEw(up::MakeArenaRef(0), up::MakeArenaRef(256), up::MakeArenaRef(512),
             0),
-      kArena, kRodata));
+      kArena, kRodata, up::kSeeuVersion));
 }
 
 TEST(PlanValidator, RejectsMisalignedRefs) {
@@ -265,7 +265,7 @@ TEST(PlanValidator, RejectsMisalignedRefs) {
   EXPECT_ERROR(ValidateInstruction(AddEw(up::MakeArenaRef(2),
                                          up::MakeArenaRef(256),
                                          up::MakeArenaRef(512), 16),
-                                   kArena, kRodata));
+                                   kArena, kRodata, up::kSeeuVersion));
   // Quantized B is 1-byte-per-element rodata: any offset is fine there.
   up::UpdateInstruction q8;
   q8.opcode = static_cast<uint16_t>(up::OpCode::kGemmNNQ8);
@@ -275,7 +275,7 @@ TEST(PlanValidator, RejectsMisalignedRefs) {
   q8.out[0] = 2;
   q8.out[1] = 2;
   q8.out[2] = 2;
-  EXPECT_OK(ValidateInstruction(q8, kArena, kRodata));
+  EXPECT_OK(ValidateInstruction(q8, kArena, kRodata, up::kSeeuVersion));
 }
 
 TEST(PlanValidator, RejectsAliasingWriteAndReadOperands) {
@@ -285,11 +285,11 @@ TEST(PlanValidator, RejectsAliasingWriteAndReadOperands) {
   EXPECT_ERROR(ValidateInstruction(
       AddEw(up::MakeArenaRef(0), up::MakeArenaRef(256), up::MakeArenaRef(32),
             16),  // write [32,96) overlaps read [0,64)
-      kArena, kRodata));
+      kArena, kRodata, up::kSeeuVersion));
   EXPECT_OK(ValidateInstruction(
       AddEw(up::MakeArenaRef(0), up::MakeArenaRef(0), up::MakeArenaRef(512),
             16),  // x and y share storage: reads may alias
-      kArena, kRodata));
+      kArena, kRodata, up::kSeeuVersion));
 }
 
 TEST(PlanValidator, EveryCompiledInstructionValidates) {

--- a/tool/seeml_seeu_dump.cc
+++ b/tool/seeml_seeu_dump.cc
@@ -59,16 +59,6 @@ const char* OpName(uint16_t opcode) {
   return "<unknown>";
 }
 
-// Overflow-checked section bound over fully untrusted header fields: the
-// unchecked form `offset + count * elem <= size` wraps modulo 2^64 for a
-// crafted count and "passes", walking the disassembler off the buffer —
-// in the one tool whose job is inspecting corrupt plans.
-bool SectionOk(uint64_t offset, uint64_t count, uint64_t elem, size_t size) {
-  if (elem != 0 && count > UINT64_MAX / elem) return false;
-  const uint64_t bytes = count * elem;
-  return offset <= size && bytes <= size - offset;
-}
-
 void PrintRef(uint64_t ref) {
   if (ref == kNullRef) {
     std::printf("  <null>          ");


### PR DESCRIPTION
# Code review: repair merge damage (main uncompilable again) + close two engine-contract gaps

Full review of the current `main` (post PR #34/#35), driven by three passes: a line-by-line audit of the unreviewed merge delta, a cross-parent sweep for content the merge resolutions dropped, and independent subsystem reviews of the kernels, runtime, and compiler backend. Two commits.

## Commit 1 — the PR #34/#35 merge resolutions left main uncompilable (same failure mode as PR #33)

- **`host_arch.cc`** — the merge deleted `CacheHalfFeasible`/`FitDim` while keeping their callers (compile error). Restored, composing both sides' improvements: the feasibility gate (skip the jointly-unsatisfiable half-cache check for degenerate detected caches) now guards the overflow-safe `PanelExceedsBytes` comparison.
- **`dataset.h`** — the `ServingPos` snapshot API (used by `batch_pipeline.cc` for deterministic feeder teardown) was replaced with a duplicated `Rewind()` declaration (compile error). Restored.
- **`plan_validator.cc`** — the unknown-opcode rejection was replaced by a dead copy of the superseded `Extent`-based aliasing loop referencing undeclared identifiers (compile error). Restored — `Execute()` must never silently skip an opcode.
- **`update_engine.cc`** — the merged softmax class-width validation scanned the engine's **cleared member programs** and the **previous plan's header**, so it never fired on a fresh engine, judged re-loads against the stale plan, and mutated `num_classes_` before the transactional commit point. Rewritten over the freshly decoded local streams/header. Also deduplicated a double `data.Rewind()` in `EvaluateMetrics` and a redundant `merged_` clear in `TrainImpl`.
- **`seeml_seeu_dump.cc`** — duplicate bounds helper (`-Werror` unused-function). Removed.
- **Validator tests** — PR #34's new cases still called the pre-flags 3-arg `ValidateInstruction`.
- **Fusion driver test** — dropped its arena-size assertion: first-fit offsets are not monotone in the interval set, and PR #34's (correct) `stable_sort` tie-break change legitimately moved the high-water mark.
- New regression: `UpdateEngineLoad.RejectsClassLabelPlanWithoutSoftmax` (fails against the stale-member scan, passes now).

## Commit 2 — two engine-contract gaps

- **`ExecuteTrainOnce` skipped merge invalidation.** The finite-difference probe hook mutates the adapter parameters but was the one parameter-mutating path that did not stale out previously materialized deltas: `RunMerge → ExecuteTrainOnce → CommitToModel` would patch the source model with deltas that no longer match the adapters. Now clears `merged_` like `TrainImpl` and `LoadCheckpoint`. Regression test included.
- **Softmax label provenance was unbound.** The softmax pair is the one instruction family that dereferences data-dependent offsets (`probs[n*C + labels[n]]`, unchecked in the kernel). That is safe only because the feeder contract validates exactly the label slot's `batch` staged entries against the narrowest softmax width — but nothing bound a softmax instruction *to* that slot. A foreign plan passing every range check could point `in[1]` at arbitrary arena bytes, claim more rows than the staged batch, or omit the class-label declaration — turning unvalidated bytes into row indices, i.e. an out-of-bounds **write** through the backward kernel, despite "validated ⇒ blind dispatch is safe" being the executor contract's whole point. `VerifyExecutorContract` now requires every softmax's label operand to equal `header.label_ref`, its row count to equal `header.batch`, and `label_kind == 1`. Regression tests patch a sealed plan three ways and assert load rejection.

## Reviewed and found sound (no change)

- All executor kernels (GEMM tiling determinism, backward-matches-forward derivatives, partial-array sizing vs `kMaxParallelChunks`, NaN propagation to the loss). Two theoretical kernel issues (C==0 softmax read, N==0 NaN loss) are unreachable: the validator's zero-extent rejection refuses them before dispatch.
- Feeder pipeline teardown determinism, checkpoint hash binding, durable I/O (EINTR, TOCTOU-free commit, Windows branch present), transactional plan load.
- Compiler analysis/backend: LoRA grafting, merge builder, epilogue fuser, autodiff, optimizer synthesis, DCE, arena binder (pinning, first-fit, alignment, determinism), instruction lowering vs the ISA, native/kernel emitters, tuner.
- Known and roadmap-documented, deliberately not changed here: the conv path (`sc_high.conv2d`) still fails loudly at instruction lowering — SMF has no conv op kind, so no real input reaches it; docs/roadmap.md Project 3 owns the make-real-vs-excise decision.

All 24 suites green (280+ tests), threaded and `SEEML_THREADS=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
