### PR TITLE
Fix documentation review findings: real README, glossary, defined ter…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,132 @@
 # SeeML: An ML Update Compiler (How to Train Your Local Model)
+
+SeeML treats a machine-learning fine-tune the way an operating system treats
+a software update. On a build host, a compiler takes a frozen model, grafts
+LoRA adapters onto it (LoRA — Low-Rank Adaptation — trains a pair of small
+matrices beside each frozen weight instead of the weight itself), and
+compiles the *entire training run* — forward pass, backward pass, optimizer,
+memory plan — ahead of time into a single update plan. On the device, a small
+zero-dependency runtime executes that plan, gates the result on a measurable
+improvement, and commits the updated weights atomically — or leaves the
+device untouched.
+
+## Why compile a training run ahead of time?
+
+On-device training normally means shipping a framework runtime: dynamic
+allocation, dynamic shapes, kernel dispatch decided at run time, and numerics
+that drift with thread count. SeeML moves every one of those decisions to
+compile time, which buys three properties that matter when the thing being
+trained is a device you don't control:
+
+- **Verifiable before it runs.** The plan is a fixed instruction stream over
+  a memory arena whose size and layout were decided by the compiler. At load
+  time the runtime re-proves the bounds of every instruction operand before
+  anything executes — a corrupt or foreign plan is rejected, never partially
+  run.
+- **Reproducible anywhere.** Parallel execution is bitwise-deterministic:
+  work is chunked by problem shape, never by thread count, so the same plan,
+  data, and seed produce the same bits on an 8-core dev board and a
+  single-core target.
+- **Safe to apply.** Like an OS update, the result is gated (validation loss
+  must improve, or the device is untouched), resumable (checkpoints are
+  hash-bound to their exact plan), and committed via fsync + atomic rename —
+  a power cut leaves the old model or the new one, never a torn file.
+
+The price of this is generality — see
+[Scope and limitations](#scope-and-limitations).
+
+## Quickstart
+
+```bash
+# 1. Build host: export a PyTorch model + corpus (or use the built-in demo)
+python3 tool/export_model.py --demo out/
+
+# 2. Build host: compile the update plan into a self-contained package
+seeml-update-compile --source out/model.smf --out pkg/ \
+  --loss xent --lora-rank 8 --steps 1000 --build
+
+# 3. Device: run the update — train, gate, merge, commit
+pkg/model_update --model out/model.smf --data out/corpus.sds \
+  --out updated.smf
+```
+
+Full walkthrough, flag reference, and exit codes: [docs/usage.md](docs/usage.md).
+
+## Documentation map
+
+Read in this order:
+
+| document | what it covers |
+|---|---|
+| [docs/usage.md](docs/usage.md) | the workflow: export, compile, run on-device; every CLI flag; threading and determinism |
+| [docs/compiler.md](docs/compiler.md) | build-host compiler architecture: frontend, analysis passes, backend, driver contracts |
+| [docs/runtime.md](docs/runtime.md) | on-device runtime architecture: engine, feeder, executor, validator, custodian |
+| [docs/formats.md](docs/formats.md) | the binary formats: SMF models, SDS datasets, SEEU plans, SEKP checkpoints |
+| [test/README.md](test/README.md) | the test tree, the in-repo SeeTest harness, and how suites mirror the code |
+| [docs/roadmap.md](docs/roadmap.md) | the remaining architecture-review projects, scoped and sequenced |
+| [docs/journey.md](docs/journey.md) | how the project got here: from a C compiler to an ML update compiler |
+
+## Scope and limitations
+
+What SeeML can train today, stated up front:
+
+- **Models.** Feed-forward graphs over seven operator kinds: `MatMul`,
+  `AddBias`, `Relu`, `Gelu`, `Silu`, `Mul`, `LayerNorm` (the SMF v2
+  vocabulary). The PyTorch exporter accepts an `nn.Sequential` of `Linear`,
+  `ReLU`, `GELU`, `SiLU`, and `LayerNorm` modules. The compiler's
+  intermediate representation additionally models 2-D convolution (lowered
+  to matrix multiplication via im2col), but grouped/dilated forms are
+  rejected and the SMF container does not yet carry convolutions.
+- **Training method.** LoRA adapters on frozen `MatMul` weights only — the
+  base model is never trained directly. Optimizers: SGD or AdamW, one
+  parameter group. Losses: cross-entropy, MSE, KL distillation from a
+  teacher model, or a weighted cross-entropy + KL composite.
+- **Numerics.** Training is f32 throughout. `--quantize-base` stores the
+  *frozen* weights as int8 in read-only data; because commit applies deltas
+  to the pristine f32 source file, quantization error is never baked into
+  the committed model.
+- **Shapes.** The batch size is fixed at compile time and baked into the
+  plan; the dataset must match the compiled geometry.
+- **Target machine.** The compiler derives its cache tilings from the
+  machine it runs on (host = target). The emitted package cross-compiles
+  (set `CXX`), but tilings remain build-host-derived hints.
+- **Integrity, not authenticity.** All hashing is FNV-1a — a corruption and
+  mismatch detector, not a signature. Authenticate plans in your update
+  transport.
+
+## Prerequisites
+
+- **Build and run:** a C++23 compiler (clang or gcc). CMake is supported but
+  optional — `build/build.sh` drives a full build with `sh` alone.
+- **Model export only:** Python 3 with PyTorch (`tool/export_model.py`).
+- **On-device:** nothing. The runtime is zero-dependency and vendored into
+  every emitted package; the package builds with no access to this
+  repository.
+
+```bash
+cmake -S . -B build && cmake --build build -j && ctest --test-dir build
+# or, without CMake:
+sh build/build.sh && for t in build/seeml_*_test; do "$t"; done
+```
+
+## Glossary
+
+Terms and abbreviations used throughout the docs, defined once here. Format
+names are specified byte-for-byte in [docs/formats.md](docs/formats.md).
+
+| term | definition |
+|---|---|
+| **SMF** | SeeML Model Format (`.smf`) — the dependency-free container for source and teacher models |
+| **SDS** | SeeML Dataset (`.sds`) — the fixed-shape training corpus streamed on-device |
+| **SEEU** | SeeML Update plan (`.seeu`) — the fully compiled update: instruction streams, frozen weights, arena layout, emit table |
+| **SEKP** | SeeML Checkpoint — the mid-training state container, hash-bound to its exact plan |
+| **SIR** | SeeML Intermediate Representation — the compiler's in-memory program form, in SSA style (static single assignment: every value is defined exactly once) |
+| **LoRA** | Low-Rank Adaptation — fine-tuning via a pair of small matrices `A` (n×r) and `B` (r×m) per frozen weight; the trained delta is `Δ = (α/r)·A@B` |
+| **GEMM** | general matrix–matrix multiply — the workhorse kernel of both training and merging |
+| **arena** | the runtime's single memory allocation, laid out entirely at compile time into read-only, persistent (checkpointed), I/O, and transient segments |
+| **plan** | the `.seeu` artifact: everything the device needs to run one complete update |
+| **AOT** | ahead-of-time — decided at compile time on the build host, not on the device |
+| **subsystem** | a top-level folder of `compiler/` or `runtime/`, named for its role in the process |
+| **discipline** | a folder inside a subsystem, named for the kind of work done by the units inside it |
+| **unit** | one class or function family with its own header — the granularity of diagnostics and tests |
+| **façade header** | the single include that re-exports a folder's units, so the files behind it can be reorganized without touching consumers |

--- a/docs/compiler.md
+++ b/docs/compiler.md
@@ -1,13 +1,27 @@
 # The SeeML Update Compiler — Architecture
 
-`compiler/` is partitioned into five subsystems, each named for its role in
-the compilation, and each subsystem into folders named for the discipline of
-the work inside it. A folder's façade header (where one exists) is the only
-include consumers need; the units behind it can be reorganized without
-churning the rest of the tree.
+Four structural terms recur throughout these docs (the [README
+glossary](../README.md#glossary) collects the full vocabulary): a
+*subsystem* is a top-level folder named for its role in the process; a
+*discipline* is a folder inside a subsystem, named for the kind of work
+done there; a *unit* is one class or function family with its own header;
+and a *façade header* is the single include that re-exports a folder's
+units, so the files behind it can be reorganized without churning the rest
+of the tree.
+
+The compiler consumes SMF (the SeeML Model Format, the on-disk model
+container — [formats.md](formats.md)), works on SIR (the SeeML Intermediate
+Representation, its in-memory program form), and produces a `.seeu` update
+plan. The update it compiles is a LoRA fine-tune (Low-Rank Adaptation: a
+pair of small trainable matrices `A` and `B` grafted beside each frozen
+weight, whose scaled product `Δ = (α/r)·A@B` is the trained delta).
+
+`compiler/` is partitioned into five subsystems, each subsystem into
+disciplines:
 
 ```
 source/                     the source language (not a compiler subsystem)
+tool/                       the command-line surface (not a compiler subsystem)
 compiler/
   driver/                   orchestrates the process, verifies every boundary
   frontend/                 SMF bytes -> forward SIR
@@ -83,9 +97,11 @@ stage of compilation. Partitioned by functionality in the same fashion:
   whole-graph checks first (`sema`: topological order, unique outputs,
   producible model output), then per-op shape semantics, with
   `value_resolver` materializing frozen weights on first use and recording
-  them in `GraphBuild` for rodata packing and the emit table.
-- **`representation/`** — SIR, the SSA intermediate representation, split
-  per core definition (`type` / `value` / `operation` / `block`) behind the
+  them in `GraphBuild` for rodata (read-only data) packing and the emit
+  table.
+- **`representation/`** — SIR, the intermediate representation, in SSA
+  form (static single assignment: every value is defined exactly once),
+  split per core definition (`type` / `value` / `operation` / `block`) behind the
   `sir.h` façade. `Block::verify()` is the invariant gate the rest of the
   compiler leans on. Threading model: single writer — use-lists are written
   during construction, so a block is built by one thread, then freely read
@@ -101,14 +117,14 @@ flow.
 
 ## compiler/analysis/ — the training program
 
-All eight units re-exported by the `update_passes.h` façade.
+Every unit below is re-exported by the `update_passes.h` façade.
 
 - **`updater/`** — orchestration and structural lowering. `PassManager`
   runs named passes and re-verifies the block after each one, so a
   corrupting rewrite is attributed to its author; a pass's own error is
   propagated verbatim. `ConvLowering` rewrites `sc_high.conv2d` into
-  im2col + filter-matrix + GEMM (+ bias) + col2im, rejecting group/dilated
-  forms it cannot model. `DeadCodeElimination` is the optimization phase's
+  im2col + filter-matrix + GEMM (general matrix–matrix multiply) + bias +
+  col2im, rejecting group/dilated forms it cannot model. `DeadCodeElimination` is the optimization phase's
   sweep, run after autodiff and optimizer synthesis: every op whose
   results are unrooted (roots: the loss slot, parameter gradients, the
   primal snapshot the eval program lowers) and unused is removed — the
@@ -138,8 +154,8 @@ All eight units re-exported by the `update_passes.h` façade.
   compiles the reference form.
 - **`calculus/`** — the mathematics of the update. `TrainableAutodiff` is
   reverse-mode autodiff pruned to the trainable set (needs-grad marking,
-  a VJP rule registry; frozen and teacher subgraphs get no backward
-  compute). `OptimizerSynthesizer` appends SGD or AdamW as SIR, so one
+  a registry of VJP — vector–Jacobian product — rules; frozen and teacher
+  subgraphs get no backward compute). `OptimizerSynthesizer` appends SGD or AdamW as SIR, so one
   program execution is one full training step.
 - **`reviewer/`** — preprocessing that configures backend behavior:
   `SelectQuantizedWeights` scans frozen weights (parallel max-abs sweep,
@@ -158,11 +174,13 @@ All eight units re-exported by the `update_passes.h` façade.
   backward transposes, and the merge's scaled accumulate) from a `GpuTiling`
   clamped out of the host tiling.
 - **`architecture/`** — local device analysis informing the trainer.
-  `DetectHostArch` reads ISA/SIMD/FMA from the compilation target (host =
+  `DetectHostArch` reads the instruction set (ISA), vector width (SIMD),
+  and fused multiply–add (FMA) support from the compilation target (host =
   target for this compiler) and cache/core geometry from sysctl on macOS
   and the sysfs CPU topology (physical cores, not hardware threads) plus
   sysconf on Linux, warning and falling back when a probe comes back
-  empty. `SuggestGemmTiling` derives BLIS-style blocking (kc×nc panel in
+  empty. `SuggestGemmTiling` derives BLIS-style blocking (the cache-blocking
+  scheme of the BLIS linear-algebra library: kc×nc panel in
   half of L1, mc×kc in half of L2) as a pure function of the host
   description, and `ValidateGemmTiling` enforces that contract —
   overflow-safely, since it is the trust boundary for deserialized
@@ -172,8 +190,8 @@ All eight units re-exported by the `update_passes.h` façade.
   GEMM as build-line defines, overridable via `SEEML_TILE_FLAGS` when
   cross-compiling for a device with different caches.
 - **`tuner/`** — reinforcement tuning that refines the architecture hint on
-  the real machine. `Ucb1Bandit` is a deterministic UCB1 multi-armed bandit
-  (no RNG; ties break to the lowest index). `TilingCandidates` spans the
+  the real machine. `Ucb1Bandit` is a deterministic UCB1 (Upper Confidence
+  Bound) multi-armed bandit (no RNG; ties break to the lowest index). `TilingCandidates` spans the
   hint and its halved/doubled neighbors; `AutotuneGemmTiling` spends an
   injected measurement budget (the benchmark is a parameter, so tuning is
   testable without a GPU or wall clock) and reports the winning tiling with
@@ -221,6 +239,20 @@ it verifies at every boundary that each subsystem was used correctly
 
 Contract violations are driver bugs, not user errors, and report under the
 driver's own unit.
+
+## tool/ — the command-line surface
+
+Not under `compiler/` for the same reason as `source/`: the tools are
+consumers of the compiler and the formats, not stages of compilation.
+
+- **`seeml_update_compile.cc`** — the compiler CLI; every flag is
+  documented in [usage.md](usage.md). Argument parsing is strict: an
+  unknown flag, a flag missing its value, or a numeric with trailing
+  garbage is a hard error, never a silent default.
+- **`seeml_seeu_dump.cc`** — the plan disassembler: header fields, arena
+  segments, and (with `--instrs`) the decoded instruction streams.
+- **`export_model.py`** — the PyTorch exporter producing SMF models and
+  SDS corpora; the accepted module set is listed in [usage.md](usage.md).
 
 ## Testing
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -2,10 +2,12 @@
 
 All formats are little-endian; loaders reject big-endian hosts at compile
 time. Every multi-byte integer is packed without padding unless a struct is
-shown (structs are `#pragma pack(1)` and part of the ABI). Integrity hashing
-comes from `source/identity/hash.h` — the deterministic parallel
-`ContentHash64` for whole-artifact identity, and its sibling `PlanSelfHash`
-for a blob whose hash field lives inside the sealed bytes — a
+shown (structs are `#pragma pack(1)` and part of the ABI — the application
+binary interface, the byte contract the compiler and runtime share).
+Integrity hashing comes from `source/identity/hash.h` — the deterministic
+parallel `ContentHash64` for whole-artifact identity, and its sibling
+`PlanSelfHash` for a blob whose hash field lives inside the sealed bytes,
+both chunked folds of 64-bit FNV-1a (Fowler–Noll–Vo). Hashing is a
 corruption/mismatch detector, not a signature; authenticate plans in your
 update transport.
 
@@ -70,7 +72,7 @@ plans' predecessors; semantic breaks (a field changing meaning or layout)
 raise `kSeeuOldestReadable`, because misreading an old plan is worse than
 rejecting it. Plans newer than the runtime are always rejected.
 
-The fully AOT-compiled update: three instruction streams (train / eval /
+The fully ahead-of-time (AOT) compiled update: three instruction streams (train / eval /
 merge), the frozen weights, the persistent segment's initial image, and the
 emit table, addressed by a single `PlanHeader` (authoritative definition:
 `source/plan/schema.h`).
@@ -88,10 +90,13 @@ Key header fields:
 Version history: v2 added the eval program, integrity hashes, LR schedule,
 and int8 rodata opcodes; v3 moved `source_model_hash` to `ContentHash64`;
 v4 moved `plan_hash` to the chunked-parallel `PlanSelfHash`; v5 gave the
-instruction's `flags` word meaning (fused GEMM epilogues — below). The
-version gate rejects plans below the readable floor — recompile. Loaders additionally prove `batch`
-nonzero and every I/O slot and instruction operand ref element-aligned;
-misaligned refs are load errors, not UB at dispatch.
+instruction's `flags` word meaning (epilogues fused into the GEMM —
+general matrix–matrix multiply — instructions; below). The version gate
+rejects plans below the readable floor — recompile.
+
+Loaders additionally prove `batch` nonzero and every I/O slot and
+instruction operand ref element-aligned; misaligned refs are load errors,
+not UB at dispatch.
 
 Tensor references are 64-bit words: bit 63 selects the address space
 (0 = mutable arena, 1 = read-only rodata), bits 0..62 are a byte offset.
@@ -109,8 +114,9 @@ would, so fusion changes memory traffic, never bits. The validator rejects
 unknown flag bits from v5 on, flags on any other opcode, and any nonzero
 flags in a pre-v5 plan.
 
-The emit table (`EmitEntry[]`) maps each adapter's **delta** (`Δ = (α/r)·A@B`,
-materialized by the merge program) to the f32 byte range of its weight inside
+The emit table (`EmitEntry[]`) maps each LoRA (Low-Rank Adaptation)
+adapter's **delta** (`Δ = (α/r)·A@B`, the adapter pair's product scaled by
+α over rank r, materialized by the merge program) to the f32 byte range of its weight inside
 the source `.smf`. Commit applies `W' = W + Δ` onto the file's pristine
 weights — a quantized plan never bakes quantization error into the committed
 model.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,8 @@ exact memory gating, tiling wiring, CI, gate accuracy, version negotiation,
 streaming/locked commit, the DCE optimization phase). Three findings remain,
 each a genuine project rather than a fix. This outline scopes them: what to
 build, in what order, against which seams in the current tree, and how each
-is verified. Effort marks are relative (S/M/L per phase).
+is verified. Effort marks are relative (S/M/L per phase). Terms and
+abbreviations are defined in the [README glossary](../README.md#glossary).
 
 Cross-cutting ground rules, all now in place and to be leaned on:
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -2,11 +2,11 @@
 
 `runtime/` is the zero-dependency half of the product: the code vendored
 into every emitted package and executed on the device. It is partitioned in
-the same fashion as [the compiler](compiler.md) — subsystems named for
-their role in the update, folders for the discipline of the work inside,
-façade headers where a subsystem's units are split — with the engine
-playing the driver's role: it owns the *process* and verifies every
-boundary it crosses.
+the same fashion as [the compiler](compiler.md), with the same structural
+vocabulary — subsystems, disciplines, units, façade headers — defined
+there and collected in the [README glossary](../README.md#glossary). The
+engine plays the driver's role: it owns the update *process* and verifies
+every boundary it crosses.
 
 ```
 runtime/
@@ -89,7 +89,8 @@ the source-model identity check uses the parallel `ContentHash64`.
 
 ## feeder/ — the corpus
 
-- **`dataset`** — the SDS container ([formats.md](formats.md)): fully
+- **`dataset`** — the SDS (SeeML Dataset) container
+  ([formats.md](formats.md)): fully
   validated before the first sample is served; batches served sequentially
   with wraparound or through a seeded per-epoch permutation, deterministic
   and allocation-free per batch.
@@ -109,9 +110,12 @@ kernel family, all sharing `kernel_policy.h` — the decomposition policy
 that makes parallel execution bitwise-deterministic (chunk boundaries are a
 pure function of the problem shape; reductions combine per-chunk partials
 in chunk order) and the no-overlap aliasing contract the arena allocator
-guarantees.
+guarantees. Determinism is a tested contract: the `ParallelDeterminism`
+suite (`test/runtime/executor/kernels_test.cc`) re-proves every kernel
+family bit-for-bit across thread counts.
 
-- **`gemm`** — the four f32 variants and two dequantizing int8 variants,
+- **`gemm`** — GEMM (general matrix–matrix multiply): the four f32
+  variants and two dequantizing int8 variants,
   reduced to two cache-blocked cores. The forward GEMMs apply the v5 fused
   epilogue (`C = act(A@B + bias)`) in the write-back while the rows are
   still hot — the per-element expressions are the same inline functions the
@@ -158,7 +162,8 @@ written.
   `WriteFile`, `FlushFileBuffers`, `MoveFileEx` with replace-existing —
   CRT `rename` cannot overwrite, which would fail every checkpoint after
   the first).
-- **`checkpoint`** — the SEKP container (v3): the arena's persistent
+- **`checkpoint`** — the SEKP (SeeML Checkpoint) container (v3): the
+  arena's persistent
   segment, hash-bound to the exact plan that laid it out and integrity-
   hashed with the parallel `ContentHash64`; fully verified before a byte
   reaches the arena.
@@ -181,8 +186,8 @@ no logger).
 
 Every unit above (plus the `source/plan/` ABI headers,
 `source/identity/hash.h`, and the `source/parallel/` substrate) is vendored into the emitted package by the
-compiler's `native_emitter`, whose generated `build.sh` compiles the
-thirteen runtime translation units and links `model_update` — the package
+compiler's `native_emitter`, whose generated `build.sh` compiles every
+runtime translation unit and links `model_update` — the package
 builds with no access to this repository.
 
 ## Testing

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,14 +1,17 @@
 # SeeML Update Compiler — Usage
 
-SeeML compiles an on-device model update ahead of time: LoRA adapters are
-grafted onto a frozen model, the backward pass and optimizer are synthesized
-as a fixed instruction stream bound to a pre-planned arena, and the result is
-executed on-device by a zero-dependency VM. One `.seeu` plan = one complete,
-gated, resumable, atomically-committed update.
+SeeML compiles an on-device model update ahead of time: LoRA adapters
+(Low-Rank Adaptation: a pair of small trainable matrices per frozen weight)
+are grafted onto a frozen model, the backward pass and optimizer are
+synthesized as a fixed instruction stream bound to a pre-planned memory
+arena, and the result is executed on-device by a zero-dependency virtual
+machine (VM). One `.seeu` plan = one complete, gated, resumable,
+atomically-committed update.
 
 How the compiler is organized internally: [compiler.md](compiler.md);
 the on-device runtime: [runtime.md](runtime.md).
 The binary formats they read and write: [formats.md](formats.md).
+Terms and abbreviations: the [README glossary](../README.md#glossary).
 
 ## 1. Export the model (build host, PyTorch)
 
@@ -24,6 +27,11 @@ export_smf(sequential_model, "model.smf")   # Linear/ReLU/GELU/SiLU/LayerNorm
 export_sds(inputs, labels, "corpus.sds")    # labels: int32 classes, dense f32, or None
 ```
 
+`export_smf` accepts an `nn.Sequential` of `Linear`, `ReLU`, `GELU`,
+`SiLU`, and `LayerNorm` modules (`Linear` weights are stored transposed
+from PyTorch's layout); `export_sds` takes fixed-shape inputs with class,
+dense, or no labels.
+
 ## 2. Compile the update plan (build host)
 
 ```bash
@@ -37,10 +45,37 @@ seeml-update-compile \
   --steps 1000 --report pkg/report.json --build
 ```
 
+Every flag (parsing is strict — an unknown flag, a flag missing its value,
+or a numeric with trailing garbage is a hard error, never a silent
+default):
+
+| flag | meaning (default) |
+|---|---|
+| `--source model.smf` | the on-device model to update (required) |
+| `--out dir/` | emission directory (required) |
+| `--data-batch N` | compiled batch size (32) |
+| `--loss xent\|mse\|kl\|xent+kl` | training objective (`xent`) |
+| `--teacher t.smf` | open-weights teacher model, for `kl` / `xent+kl` |
+| `--distill-weight W` | KL weight in the composite loss (0.5) |
+| `--temperature T` | distillation temperature (2.0) |
+| `--lora-rank R` / `--lora-alpha A` / `--lora-seed S` | adapter rank / scale / init seed (8 / 16 / 42) |
+| `--targets substr,substr` | restrict adapters to weights whose names match |
+| `--optimizer adamw\|sgd` | optimizer (`adamw`) |
+| `--lr LR` / `--weight-decay WD` | learning rate / decay (1e-3 / 0.01) |
+| `--clip-norm C` | per-tensor L2 gradient clip (0 = off) |
+| `--lr-schedule const\|cosine` | runtime LR schedule (`const`) |
+| `--warmup N` / `--min-lr-factor F` | warmup steps / cosine floor as a fraction of `--lr` (0 / 0) |
+| `--quantize-base` | int8-quantize frozen weights in rodata |
+| `--steps N` | default step count baked into the plan (1000) |
+| `--no-fuse-epilogue` | compile the unfused reference form |
+| `--report out.json` | machine-readable compile report |
+| `--build` | run the emitted `build.sh` after emission |
+
 Distillation from an open-weights teacher: `--loss kl --teacher teacher.smf`
 (unlabeled corpus), or `--loss xent+kl --distill-weight 0.5`.
 
-GEMM→AddBias→activation chains with no backward reader (the frozen teacher,
+GEMM (general matrix–matrix multiply) → AddBias → activation chains with
+no backward reader (the frozen teacher,
 unadapted layers) are fused into single-instruction epilogues by default —
 bitwise-identical results, fewer arena round-trips. `--no-fuse-epilogue`
 compiles the unfused reference form.
@@ -63,6 +98,20 @@ model_update --model model.smf --data corpus.sds --out updated.smf \
   --checkpoint state.ckpt --checkpoint-every 100 --resume \
   --loss-log curve.csv
 ```
+
+| flag | meaning (default) |
+|---|---|
+| `--model source.smf` | the model the plan was compiled from (required; must hash-match the plan) |
+| `--data corpus.sds` | the training corpus (required) |
+| `--out updated.smf` | where the committed model is written (`updated_model.smf`) |
+| `--steps N` | training steps (0 = the plan's compiled default) |
+| `--seed S` | shuffle-permutation seed (0) |
+| `--val-frac F` | held-out fraction for the regression gate (0.1); 0 gates on the training-loss trend instead |
+| `--checkpoint path` | checkpoint file, hash-bound to the plan |
+| `--checkpoint-every N` | steps between checkpoints (0 = off) |
+| `--resume` | resume from `--checkpoint` if present |
+| `--loss-log curve.csv` | write the per-step loss curve |
+| `--force` | commit even if the gate shows no improvement |
 
 What happens, in order:
 
@@ -107,6 +156,12 @@ and reductions combine per-chunk partials in a fixed order. The same plan,
 data, and seed produce the same bits at any thread count — thread count is a
 throughput knob, not a numerics knob — so a loss curve from an 8-core dev
 board reproduces exactly on a single-core target.
+
+This is a tested contract, not an aspiration:
+`ParallelFor.OrderedPartialReductionIsBitwiseThreadCountInvariant`
+(`test/source/parallel/parallel_for_test.cc`) proves the substrate, and
+the `ParallelDeterminism` suite (`test/runtime/executor/kernels_test.cc`)
+re-proves every kernel family bit-for-bit across thread counts.
 
 ## Development
 

--- a/test/README.md
+++ b/test/README.md
@@ -2,8 +2,11 @@
 
 Organized in the same fashion as the `compiler/` and `runtime/` subsystems:
 the harness and fixtures are partitioned per discipline behind façade
-headers, and the suites mirror the subsystem partition of the code they
-verify — a suite lives where its subject lives.
+headers (structural vocabulary — *subsystem*, *discipline*, *unit*,
+*façade header* — as defined in [docs/compiler.md](../docs/compiler.md)
+and the [README glossary](../README.md#glossary)), and the suites mirror
+the subsystem partition of the code they verify — a suite lives where its
+subject lives.
 
 ```
 test/
@@ -13,7 +16,7 @@ test/
     assert.h            the TEST / EXPECT_* / ASSERT_* macro surface
     seetest_main.cc     the runner main linked into every suite
   support/              shared fixtures (façade: builders.h)
-    models.cc           deterministic SMF model builders + BaseConfig
+    models.cc           deterministic SMF (SeeML Model Format) model builders + BaseConfig
     corpora.cc          synthetic datasets (classification/regression/unlabeled)
     probes.cc           engine-arena introspection + the test-run environment
     scoped_temp_dir     filesystem sandbox for I/O suites


### PR DESCRIPTION
…ms, tool/ coverage, CLI flag reference

- README.md: full front page — pitch, AOT motivation, quickstart, doc map, scope & limitations, prerequisites, and a glossary defining every term and abbreviation used across the docs
- compiler.md: structural vocabulary defined before use; SMF/SIR/LoRA/GEMM/ SSA/VJP/UCB1/ISA/SIMD/FMA/BLIS/rodata expanded at first use; tool/ added to the tree with its own section; wrong 'eight units' count (facade exports nine) replaced with uncounted phrasing
- runtime.md: dense opener split; SDS/SEKP/GEMM expanded; brittle 'thirteen translation units' count dropped; determinism claim now cites the ParallelDeterminism suite
- formats.md: ABI/AOT/FNV-1a/GEMM/LoRA expanded at first use; overlong version-history paragraph split
- usage.md: complete flag reference tables for seeml-update-compile and model_update (defaults verified against the sources); exporter's accepted module set stated in prose; determinism claim tied to the tests that prove it
- roadmap.md, test/README.md: glossary pointers and first-use expansions