### PR TITLE
Fix all 11 findings from the main-branch triple-lens review

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,18 @@ Read in this order:
 
 What SeeML can train today, stated up front:
 
-- **Models.** Feed-forward graphs over seven operator kinds: `MatMul`,
-  `AddBias`, `Relu`, `Gelu`, `Silu`, `Mul`, `LayerNorm` (the SMF v2
-  vocabulary). The PyTorch exporter accepts an `nn.Sequential` of `Linear`,
-  `ReLU`, `GELU`, `SiLU`, and `LayerNorm` modules. The compiler's
-  intermediate representation additionally models 2-D convolution (lowered
-  to matrix multiplication via im2col), but grouped/dilated forms are
-  rejected and the SMF container does not yet carry convolutions.
+- **Models.** Feed-forward and decoder-transformer graphs over eleven
+  operator kinds: `MatMul`, `AddBias`, `Relu`, `Gelu`, `Silu`, `Mul`,
+  `LayerNorm` (SMF v2), plus `Add`, `RmsNorm`, `Rope`, and causal
+  `Attention` (SMF v3, with model-level sequence geometry) — enough for
+  pre-norm decoder blocks with SwiGLU MLPs. The PyTorch exporter accepts an
+  `nn.Sequential` of `Linear`/activation/`LayerNorm` modules, and
+  `export_decoder_smf` emits decoder stacks from plain weight arrays
+  (embedding lookup stays outside the update: corpora carry pre-embedded
+  rows). The compiler's intermediate representation additionally models 2-D
+  convolution (lowered to matrix multiplication via im2col), but
+  grouped/dilated forms are rejected and the SMF container does not yet
+  carry convolutions.
 - **Training method.** LoRA adapters on frozen `MatMul` weights only — the
   base model is never trained directly. Optimizers: SGD or AdamW, one
   parameter group. Losses: cross-entropy, MSE, KL distillation from a
@@ -89,7 +94,9 @@ What SeeML can train today, stated up front:
   plan; the dataset must match the compiled geometry.
 - **Target machine.** The compiler derives its cache tilings from the
   machine it runs on (host = target). The emitted package cross-compiles
-  (set `CXX`), but tilings remain build-host-derived hints.
+  (set `CXX`), but tilings remain build-host-derived hints. Execution is
+  CPU; on Apple hosts a hardware-validated Metal GEMM dispatch harness
+  exists (roadmap Project 5), but the engine does not yet dispatch to it.
 - **Integrity, not authenticity.** All hashing is FNV-1a — a corruption and
   mismatch detector, not a signature. Authenticate plans in your update
   transport.

--- a/compiler/analysis/reviewer/quantization.cc
+++ b/compiler/analysis/reviewer/quantization.cc
@@ -42,8 +42,14 @@ std::unordered_map<const sir::Value*, float> SelectQuantizedWeights(
     const size_t chunks = ParallelChunkCount(count, kWeightSweepGrain);
     for (size_t c = 0; c < chunks; ++c) max_abs = std::max(max_abs, partials[c]);
     // An all-zero weight quantizes to zeros under any scale; 1.0 keeps the
-    // reciprocal finite.
-    scales[v] = max_abs > 0.0f ? max_abs / 127.0f : 1.0f;
+    // dequant multiply finite. A subnormal-range tensor is NOT selected at
+    // all: its scale would be denormal (or underflow to exactly 0), so the
+    // pack's rounding and the runtime's dequant multiply both degenerate —
+    // quantizing to garbage or to all zeros. Such a tensor stays f32
+    // rodata; skipping a selection is always sound.
+    const float scale = max_abs > 0.0f ? max_abs / 127.0f : 1.0f;
+    if (!std::isnormal(scale)) return;
+    scales[v] = scale;
   });
   return scales;
 }

--- a/compiler/backend/trainer/arena_binder.cc
+++ b/compiler/backend/trainer/arena_binder.cc
@@ -146,10 +146,15 @@ std::expected<ArenaBinding, std::string> BindArena(
       const size_t count = src->second->byte_size / sizeof(float);
       binding.rodata.resize(offset + count, 0);
       auto* dst = reinterpret_cast<int8_t*>(binding.rodata.data() + offset);
-      const float inv_scale = 1.0f / q->second;
+      // Divide, don't multiply by a hoisted reciprocal: for a denormal
+      // scale 1/scale is +Inf, which clamps every nonzero element to ±127
+      // and turns zeros into clamp(NaN) — UB on the int8 cast. The
+      // quantizer refuses denormal scales, but the pack must not rely on
+      // that upstream discipline for memory safety.
+      const float scale = q->second;
       ParallelFor(count, kWeightSweepGrain, [&](size_t b, size_t e, size_t) {
         for (size_t i = b; i < e; ++i) {
-          const float r = std::round(data[i] * inv_scale);
+          const float r = std::round(data[i] / scale);
           dst[i] = static_cast<int8_t>(std::clamp(r, -127.0f, 127.0f));
         }
       });

--- a/compiler/driver/update_compiler.cc
+++ b/compiler/driver/update_compiler.cc
@@ -53,12 +53,27 @@ std::expected<CompiledUpdate, std::string> UpdateCompiler::CompileImpl(
     return generating::Error(generating::kDriver,
                              "source model lacks input metadata");
   const int64_t in_dim = in_tensor->dims.back();
+  // The reader restricts the dynamic (-1) marker to the leading dim, but
+  // this is the driver's own contract too: a non-positive width here would
+  // flow into the SIR as a dynamic dim, bind zero-byte slots, and produce
+  // a sealed plan the runtime rejects — a compiler bug surfaced as a
+  // validator error.
+  if (in_dim <= 0)
+    return generating::Error(generating::kDriver,
+                             "source model input width must be static and "
+                             "positive");
   const int64_t batch = config_.batch;
 
   // --- 0. Fail fast: prove the training footprint fits local memory. -------
+  // The teacher is a frozen forward — no backward caches its activations —
+  // so it is estimated at its peak, not its sum; and --quantize-base stores
+  // frozen weights as int8 rodata at 1/4 size (under-counting the
+  // unselected remainder keeps the bound a lower bound). Both matter:
+  // an over-count here refuses compiles the exact final gate would pass.
   TrainingFootprint footprint = EstimateTrainingFootprint(source, batch);
   if (wants_teacher)
-    footprint += EstimateTrainingFootprint(*teacher, batch);
+    footprint += EstimateFrozenForwardFootprint(*teacher, batch);
+  if (config_.quantize_base) footprint.weight_bytes /= 4;
   if (auto fits = CheckTrainableLocally(footprint, config_.memory_budget_bytes);
       !fits)
     return std::unexpected(fits.error());
@@ -73,6 +88,9 @@ std::expected<CompiledUpdate, std::string> UpdateCompiler::CompileImpl(
   if (!student_out) return std::unexpected(student_out.error());
   build.output = *student_out;
   const int64_t out_dim = build.output->shape().dims.at(1);
+  if (out_dim <= 0)
+    return generating::Error(generating::kDriver,
+                             "model output width must be static and positive");
 
   sir::Value* teacher_out = nullptr;
   if (wants_teacher) {

--- a/compiler/frontend/ingressor/model_reader.cc
+++ b/compiler/frontend/ingressor/model_reader.cc
@@ -131,14 +131,18 @@ std::expected<SmfModel, std::string> LoadSmf(const std::string& path) {
     // the tensor ("invalid dims") for what is really a cut-off file.
     if (!r.ok) return tokenizing::FileError("truncated file", path);
 
-    // Dims must be strictly positive — except a dynamic (-1) dim on non-const
-    // tensors, which the compiler binds to the compiled batch size — with a
-    // volume that cannot overflow the signed shape math downstream
-    // (sir::Shape::volume / byteSize).
+    // Dims must be strictly positive — except a dynamic (-1) LEADING dim on
+    // non-const tensors, which the compiler binds to the compiled batch
+    // size — with a volume that cannot overflow the signed shape math
+    // downstream (sir::Shape::volume / byteSize). A -1 anywhere else has no
+    // binding rule: the driver reads dims.back() as the static input width,
+    // and a dynamic width would flow into the SIR, bind zero-byte slots,
+    // and seal a plan the runtime always rejects.
     uint64_t volume = 1;
     bool dims_ok = !t.dims.empty();
-    for (int64_t dim : t.dims) {
-      if (dim == -1 && !t.is_const) continue;
+    for (size_t d = 0; d < t.dims.size(); ++d) {
+      const int64_t dim = t.dims[d];
+      if (dim == -1 && !t.is_const && d == 0) continue;
       if (dim <= 0 || !MulU64(volume, static_cast<uint64_t>(dim), &volume) ||
           volume > static_cast<uint64_t>(INT64_MAX) / sizeof(float)) {
         dims_ok = false;

--- a/compiler/frontend/ingressor/resource_analyzer.cc
+++ b/compiler/frontend/ingressor/resource_analyzer.cc
@@ -45,9 +45,23 @@ TrainingFootprint& TrainingFootprint::operator+=(const TrainingFootprint& o) {
   return *this;
 }
 
-TrainingFootprint EstimateTrainingFootprint(const SmfModel& model,
-                                            int64_t batch) {
+namespace {
+
+/// Shared walk behind both estimators. `sum_activations` selects the
+/// training model (every activation is cached for the backward pass — sum
+/// them) or the frozen-forward model (no backward consumes anything, so
+/// transients die at their single reader and the arena binder reuses their
+/// slots — the honest lower bound is the single widest live term).
+TrainingFootprint EstimateFootprintImpl(const SmfModel& model, int64_t batch,
+                                        bool sum_activations) {
   TrainingFootprint fp;
+  uint64_t peak_activation = 0;
+  auto charge = [&](uint64_t term) {
+    if (sum_activations)
+      fp.activation_bytes = SatAdd(fp.activation_bytes, term);
+    else
+      peak_activation = std::max(peak_activation, term);
+  };
   const uint64_t rows = batch > 0 ? static_cast<uint64_t>(batch) : 0;
 
   // Frozen weights: one resident copy each (they at least fill rodata).
@@ -109,11 +123,8 @@ TrainingFootprint EstimateTrainingFootprint(const SmfModel& model,
         // LayerNorm additionally caches per-row mean/rstd for the backward
         // kernel (two f32 per row); RMSNorm caches rstd (one).
         if (op.kind == SmfOpKind::kLayerNorm)
-          fp.activation_bytes =
-              SatAdd(fp.activation_bytes, SatMul(2 * sizeof(float), r));
-        if (op.kind == SmfOpKind::kRmsNorm)
-          fp.activation_bytes =
-              SatAdd(fp.activation_bytes, SatMul(sizeof(float), r));
+          charge(SatMul(2 * sizeof(float), r));
+        if (op.kind == SmfOpKind::kRmsNorm) charge(SatMul(sizeof(float), r));
         // Attention caches the probability matrix P[B,H,S,S] — flattened
         // [rows * heads, seq_len] — for the backward primitives; usually
         // the dominant transformer activation. heads/seq_len of zero mean
@@ -121,20 +132,30 @@ TrainingFootprint EstimateTrainingFootprint(const SmfModel& model,
         // so the estimate stays a lower bound.
         if (op.kind == SmfOpKind::kAttention && op.attr0 > 0 &&
             model.seq_len > 0)
-          fp.activation_bytes = SatAdd(
-              fp.activation_bytes,
-              SatMul(SatMul(SatMul(r, op.attr0), model.seq_len),
-                     sizeof(float)));
+          charge(SatMul(SatMul(SatMul(r, op.attr0), model.seq_len),
+                        sizeof(float)));
         break;
       }
     }
     if (w == 0) continue;
     width[op.output] = w;
     row_count[op.output] = r;
-    fp.activation_bytes =
-        SatAdd(fp.activation_bytes, SatMul(SatMul(r, w), sizeof(float)));
+    charge(SatMul(SatMul(r, w), sizeof(float)));
   }
+  if (!sum_activations) fp.activation_bytes = peak_activation;
   return fp;
+}
+
+}  // namespace
+
+TrainingFootprint EstimateTrainingFootprint(const SmfModel& model,
+                                            int64_t batch) {
+  return EstimateFootprintImpl(model, batch, /*sum_activations=*/true);
+}
+
+TrainingFootprint EstimateFrozenForwardFootprint(const SmfModel& model,
+                                                 int64_t batch) {
+  return EstimateFootprintImpl(model, batch, /*sum_activations=*/false);
 }
 
 uint64_t DetectLocalMemoryBytes() {

--- a/compiler/frontend/ingressor/resource_analyzer.h
+++ b/compiler/frontend/ingressor/resource_analyzer.h
@@ -44,6 +44,15 @@ struct TrainingFootprint {
 TrainingFootprint EstimateTrainingFootprint(const SmfModel& model,
                                             int64_t batch);
 
+/// The frozen-forward variant, for teacher models under distillation: no
+/// backward pass consumes the activations, so they die at their single
+/// reader and the arena binder reuses their slots — the honest lower bound
+/// charges the single widest live term instead of the sum (which over-counts
+/// a deep teacher by more than an order of magnitude and could refuse a
+/// provably feasible compile).
+TrainingFootprint EstimateFrozenForwardFootprint(const SmfModel& model,
+                                                 int64_t batch);
+
 /// Physical memory of this host in bytes; 0 when undetectable.
 uint64_t DetectLocalMemoryBytes();
 

--- a/runtime/custodian/durable_io.cc
+++ b/runtime/custodian/durable_io.cc
@@ -5,6 +5,7 @@
 #include "source/parallel/parallel_for.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cstdio>
 #include <fstream>
 #include <utility>
@@ -15,6 +16,7 @@
 #include <sys/file.h>
 #include <unistd.h>
 #else
+#include <io.h>
 #include <windows.h>
 #endif
 
@@ -22,9 +24,30 @@ namespace seeml::update_rt {
 
 namespace up = seeml::update;
 
+namespace {
+
+/// Per-writer-unique sidecar name in the destination's directory (rename
+/// atomicity requires same-filesystem). A fixed ".tmp" would let two
+/// concurrent writers to one path interleave on a shared inode and rename
+/// a mixed-content file into place; pid + a process-local counter keeps
+/// every writer on its own sidecar. Crash leftovers are inert — nothing
+/// ever reads a sidecar it did not just create.
+std::string UniqueTmpPath(const std::string& path) {
+  static std::atomic<uint64_t> counter{0};
+#ifndef _WIN32
+  const unsigned long pid = static_cast<unsigned long>(::getpid());
+#else
+  const unsigned long pid = static_cast<unsigned long>(::GetCurrentProcessId());
+#endif
+  return path + ".tmp." + std::to_string(pid) + "." +
+         std::to_string(counter.fetch_add(1, std::memory_order_relaxed));
+}
+
+}  // namespace
+
 std::expected<void, std::string> WriteFileDurable(
     const std::string& path, std::initializer_list<ByteSpan> parts) {
-  const std::string tmp = path + ".tmp";
+  const std::string tmp = UniqueTmpPath(path);
 #ifndef _WIN32
   const int fd = ::open(tmp.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
   if (fd < 0)
@@ -165,11 +188,24 @@ std::expected<uint64_t, std::string> HashFileContent(const std::string& path) {
 
 // --- CommitLock --------------------------------------------------------------
 
+namespace {
+
+/// Releases whichever handle kind this platform stores in CommitLock.
+void ReleaseLockHandle(intptr_t handle) {
+#ifndef _WIN32
+  if (handle >= 0) ::close(static_cast<int>(handle));  // drops the flock
+#else
+  if (handle != -1) ::CloseHandle(reinterpret_cast<HANDLE>(handle));
+#endif
+}
+
+}  // namespace
+
 std::expected<CommitLock, std::string> CommitLock::Acquire(
     const std::string& target_path) {
   CommitLock lock;
-#ifndef _WIN32
   const std::string lock_path = target_path + ".lock";
+#ifndef _WIN32
   const int fd = ::open(lock_path.c_str(), O_RDWR | O_CREAT, 0644);
   if (fd < 0)
     return diag::persisting::Error(diag::persisting::kDurableIo,
@@ -181,31 +217,42 @@ std::expected<CommitLock, std::string> CommitLock::Acquire(
         "another update is committing to '" + target_path +
             "' — refusing to race it");
   }
-  lock.fd_ = fd;
+  lock.handle_ = fd;
 #else
-  (void)target_path;  // no advisory locking on the degraded Windows path
+  // dwShareMode = 0 is the exclusion: a second CreateFile on the live
+  // handle fails with a sharing violation, and process death releases it —
+  // the same crash-safe, no-stale-lock contract as flock.
+  HANDLE h = ::CreateFileA(lock_path.c_str(), GENERIC_WRITE, /*share=*/0,
+                           nullptr, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL,
+                           nullptr);
+  if (h == INVALID_HANDLE_VALUE) {
+    if (::GetLastError() == ERROR_SHARING_VIOLATION)
+      return diag::persisting::Error(
+          diag::persisting::kDurableIo,
+          "another update is committing to '" + target_path +
+              "' — refusing to race it");
+    return diag::persisting::Error(diag::persisting::kDurableIo,
+                                   "cannot open lock '" + lock_path + "'");
+  }
+  lock.handle_ = reinterpret_cast<intptr_t>(h);
 #endif
   return lock;
 }
 
-CommitLock::CommitLock(CommitLock&& o) noexcept : fd_(o.fd_) { o.fd_ = -1; }
+CommitLock::CommitLock(CommitLock&& o) noexcept : handle_(o.handle_) {
+  o.handle_ = -1;
+}
 
 CommitLock& CommitLock::operator=(CommitLock&& o) noexcept {
   if (this != &o) {
-#ifndef _WIN32
-    if (fd_ >= 0) ::close(fd_);
-#endif
-    fd_ = o.fd_;
-    o.fd_ = -1;
+    ReleaseLockHandle(handle_);
+    handle_ = o.handle_;
+    o.handle_ = -1;
   }
   return *this;
 }
 
-CommitLock::~CommitLock() {
-#ifndef _WIN32
-  if (fd_ >= 0) ::close(fd_);  // closing drops the flock
-#endif
-}
+CommitLock::~CommitLock() { ReleaseLockHandle(handle_); }
 
 // --- DurableFileEdit ---------------------------------------------------------
 
@@ -238,6 +285,16 @@ std::expected<DurableFileEdit, std::string> DurableFileEdit::Begin(
     if (in.bad())
       return diag::persisting::Error(diag::persisting::kDurableIo,
                                      "cannot read '" + source + "'");
+    // The final sub-buffer chunk may still sit in the filebuf; the
+    // destructor's flush swallows failure, which would leave a silently
+    // truncated sidecar that passes every size_-based bounds check (size_
+    // was counted from the SOURCE reads). Flush and close explicitly —
+    // close sets failbit when the flush fails.
+    out.flush();
+    out.close();
+    if (!out)
+      return diag::persisting::Error(diag::persisting::kDurableIo,
+                                     "cannot flush '" + edit.tmp_ + "'");
   }
 
   edit.f_ = std::fopen(edit.tmp_.c_str(), "r+b");
@@ -325,18 +382,32 @@ std::expected<void, std::string> DurableFileEdit::Commit() {
   if (std::fflush(f_) != 0)
     return diag::persisting::Error(diag::persisting::kDurableIo,
                                    "cannot flush '" + tmp_ + "'");
+  // Same durability discipline as WriteFileDurable on both platforms: data
+  // fsync (FlushFileBuffers) before the rename, and a rename that can
+  // replace an existing destination — CRT rename cannot on Windows, which
+  // would fail every repeat commit (the exact defect WriteFileDurable's
+  // Win32 branch documents).
 #ifndef _WIN32
-  // Same durability discipline as WriteFileDurable: data fsync before the
-  // rename, best-effort directory fsync after it.
   if (::fsync(::fileno(f_)) != 0)
     return diag::persisting::Error(diag::persisting::kDurableIo,
                                    "fsync of '" + tmp_ + "' failed");
-#endif
   std::fclose(f_);
   f_ = nullptr;
   if (std::rename(tmp_.c_str(), dest_.c_str()) != 0)
     return diag::persisting::Error(diag::persisting::kDurableIo,
                                    "atomic rename to '" + dest_ + "' failed");
+#else
+  if (!::FlushFileBuffers(
+          reinterpret_cast<HANDLE>(_get_osfhandle(_fileno(f_)))))
+    return diag::persisting::Error(diag::persisting::kDurableIo,
+                                   "fsync of '" + tmp_ + "' failed");
+  std::fclose(f_);
+  f_ = nullptr;
+  if (!::MoveFileExA(tmp_.c_str(), dest_.c_str(),
+                     MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+    return diag::persisting::Error(diag::persisting::kDurableIo,
+                                   "atomic rename to '" + dest_ + "' failed");
+#endif
   committed_ = true;
 #ifndef _WIN32
   const size_t slash = dest_.find_last_of('/');

--- a/runtime/custodian/durable_io.h
+++ b/runtime/custodian/durable_io.h
@@ -68,7 +68,10 @@ class CommitLock {
 
  private:
   CommitLock() = default;
-  int fd_ = -1;
+  // POSIX: the lock file's fd (flock dies with it). Windows: the HANDLE of
+  // a CreateFile open with dwShareMode = 0 — the share-mode refusal is the
+  // exclusion, and CloseHandle (or process death) releases it.
+  intptr_t handle_ = -1;
 };
 
 /// Copy-on-write durable editor for ranged patches. Begin() streams

--- a/runtime/engine/update_engine.cc
+++ b/runtime/engine/update_engine.cc
@@ -677,6 +677,23 @@ std::expected<TrainReport, std::string> UpdateEngine::TrainImpl(
 std::expected<void, std::string> UpdateEngine::RunMerge() {
   if (!arena_) return diag::executing::Error("no plan loaded");
   Execute(merge_program_);
+  // Finiteness gate on the materialized deltas. The training loop's loss
+  // guard reads the loss written BEFORE each step's backward + optimizer,
+  // so a gradient that overflows on the final executed step can poison the
+  // adapters with no later loss read — and the clamped xent/KL losses can
+  // never go infinite themselves. With a validation split the regression
+  // gate rejects the NaN; without one, this scan is the last line between
+  // a poisoned delta and the committed model file.
+  for (const up::EmitEntry& e : emit_table_) {
+    const auto* delta =
+        reinterpret_cast<const float*>(arena_ + e.arena_offset);
+    const size_t count = e.byte_size / sizeof(float);
+    for (size_t i = 0; i < count; ++i)
+      if (!std::isfinite(delta[i]))
+        return diag::executing::Error(
+            "merged delta contains a non-finite value — the adapters are "
+            "numerically poisoned; refusing to stage a commit");
+  }
   merged_ = true;
   return {};
 }

--- a/runtime/engine/update_engine.h
+++ b/runtime/engine/update_engine.h
@@ -151,6 +151,11 @@ class UpdateEngine {
   uint8_t* arena() { return arena_; }
   uint64_t step() const { return step_; }
   void SetStep(uint64_t s) { step_ = s; }
+  /// The scheduled learning rate at the current step — a pure function of
+  /// (header_, step_). Public so the schedule's boundary behavior (warmup
+  /// edges, horizon clamp, floor) is directly testable; it scales every
+  /// optimizer step.
+  float EffectiveLr() const;
 
   /// Executes the training instruction stream once against whatever is in the
   /// I/O slots right now (no data feeding). Used for gradient verification.
@@ -168,7 +173,6 @@ class UpdateEngine {
   [[nodiscard]] std::expected<void, std::string> ValidateDataset(
       Dataset& data) const;
   void Execute(const std::vector<seeml::update::UpdateInstruction>& program);
-  float EffectiveLr() const;  // schedule(step_) applied to header_.lr
 
   const float* ReadPtr(uint64_t ref) const;
   const int8_t* ReadPtrQ8(uint64_t ref) const;

--- a/runtime/executor/activation.cc
+++ b/runtime/executor/activation.cc
@@ -43,9 +43,18 @@ void GeluBwd(const float* dy, const float* x, float* dx, size_t n) {
       const float v = x[i];
       const float u = kGeluC * (v + kGeluA * v * v * v);
       const float t = std::tanh(u);
-      const float du = kGeluC * (1.0f + 3.0f * kGeluA * v * v);
-      // d/dv [0.5 v (1 + tanh(u))] = 0.5 (1 + t) + 0.5 v (1 - t²) u'
-      dx[i] = dy[i] * (0.5f * (1.0f + t) + 0.5f * v * (1.0f - t * t) * du);
+      // d/dv [0.5 v (1 + tanh(u))] = 0.5 (1 + t) + 0.5 v (1 - t²) u'.
+      // In the saturated regime (t² == 1 exactly) the sech² factor is a
+      // true zero while u' can overflow to +Inf for astronomically large
+      // v — 0 * Inf would emit NaN where the correct gradient is dy * 1
+      // (v > 0) or dy * 0 (v < 0). Drop the dead term instead.
+      const float one_minus_t2 = 1.0f - t * t;
+      const float tail =
+          one_minus_t2 == 0.0f
+              ? 0.0f
+              : 0.5f * v * one_minus_t2 *
+                    (kGeluC * (1.0f + 3.0f * kGeluA * v * v));
+      dx[i] = dy[i] * (0.5f * (1.0f + t) + tail);
     }
   });
 }

--- a/source/parallel/parallel_for.cc
+++ b/source/parallel/parallel_for.cc
@@ -119,7 +119,13 @@ class WorkerPool {
     // workers) and the first submitter's cleanup would null out the second's
     // freshly published job.
     std::lock_guard<std::mutex> submit(submit_mutex_);
-    tls_job_owner = true;
+    // RAII: an exception escaping anything below (worker spawn is the
+    // fallible step) must not leave the flag set, or this thread would run
+    // the inline path forever after one transient failure.
+    struct OwnerFlag {
+      OwnerFlag() { tls_job_owner = true; }
+      ~OwnerFlag() { tls_job_owner = false; }
+    } owner_flag;
     {
       std::lock_guard<std::mutex> lock(mutex_);
       SpawnWorkersLocked();
@@ -139,17 +145,25 @@ class WorkerPool {
       });
       job_ = nullptr;
     }
-    tls_job_owner = false;
     if (job.error) std::rethrow_exception(job.error);
   }
 
  private:
   void SpawnWorkersLocked() {
-    if (!workers_.empty()) return;
     if (thread_count_ == 0) thread_count_ = ResolveAutoThreadCount();
     // The caller participates, so the pool holds thread_count_ - 1 workers.
-    for (size_t i = 1; i < thread_count_; ++i)
-      workers_.emplace_back([this] { WorkerLoop(); });
+    // Top-up, not spawn-once, and degrade instead of aborting: a
+    // std::thread constructor throwing (thread/resource exhaustion) runs
+    // this job at whatever width exists — chunk geometry is shape-based,
+    // so results are identical — and the next Run retries the missing
+    // workers instead of freezing the narrowed pool forever.
+    while (workers_.size() + 1 < thread_count_) {
+      try {
+        workers_.emplace_back([this] { WorkerLoop(); });
+      } catch (const std::system_error&) {
+        break;
+      }
+    }
   }
 
   void JoinWorkers() {

--- a/test/compiler/analysis/reviewer_test.cc
+++ b/test/compiler/analysis/reviewer_test.cc
@@ -64,6 +64,22 @@ TEST(Reviewer, SelectsMatmulOnlyWeightsAtMaxAbsScale) {
   EXPECT_NEAR(scales.at(w), 3.0f / 127.0f, 1e-7);
 }
 
+TEST(Reviewer, SkipsSubnormalRangeTensors) {
+  // A subnormal max_abs yields a denormal (or underflowed-to-zero) scale:
+  // the pack's rounding and the runtime's dequant multiply both degenerate,
+  // so such a tensor must stay f32 rodata rather than be selected.
+  sir::Block block;
+  GraphBuild build;
+  sir::Value* x = block.addArgument(sir::DataType::F32, sir::Shape{4, 2});
+  SmfTensor tensor;
+  sir::Value* w = AddWeight(block, build, tensor, "w", {2, 2},
+                            std::vector<float>(4, 1e-40f));
+  AddMatmul(block, "y", x, w);
+
+  const auto scales = SelectQuantizedWeights(block, build);
+  EXPECT_EQ(scales.size(), 0u);
+}
+
 TEST(Reviewer, RejectsWeightsConsumedAsActivations) {
   sir::Block block;
   GraphBuild build;

--- a/test/compiler/frontend/model_io_test.cc
+++ b/test/compiler/frontend/model_io_test.cc
@@ -76,6 +76,19 @@ TEST(Smf, SaveLoadRoundTrip) {
   }
 }
 
+TEST(Smf, LoadRejectsDynamicDimBeyondLeading) {
+  // The dynamic (-1) marker binds to the compiled batch and is only
+  // meaningful as the LEADING dim; anywhere else it would flow into the
+  // SIR as a dynamic width, bind zero-byte slots, and seal a plan the
+  // runtime always rejects.
+  ScopedTempDir dir;
+  SmfModel model = MakeMlp(4, 8, 2, 1);
+  model.tensors[0].dims = {4, -1};  // x: dynamic width instead of batch
+  const std::string path = dir.File("dynwidth.smf");
+  ASSERT_OK(SaveSmf(path, model));
+  EXPECT_ERROR_CONTAINS(LoadSmf(path), "invalid dims");
+}
+
 TEST(Smf, SaveLoadRoundTripsV3TransformerFields) {
   // The v3 additions — model seq_len, per-op attr0, and the transformer op
   // kinds — must survive the byte round trip.

--- a/test/compiler/frontend/resource_analyzer_test.cc
+++ b/test/compiler/frontend/resource_analyzer_test.cc
@@ -94,4 +94,19 @@ TEST(ResourceAnalyzer, CompilerAcceptsModelWithinBudget) {
   ASSERT_OK(UpdateCompiler(config).Compile(model));
 }
 
+TEST(ResourceAnalyzer, FrozenForwardEstimateChargesPeakNotSum) {
+  // A teacher under distillation has no backward: its transients die at
+  // their single reader and the binder reuses their slots, so the honest
+  // lower bound is the single widest live activation — summing them (the
+  // training model) over-counts and can refuse a feasible compile.
+  SmfModel model = MakeMlp(4, 8, 2, /*seed=*/1);
+  const TrainingFootprint train = EstimateTrainingFootprint(model, kBatch);
+  const TrainingFootprint frozen =
+      EstimateFrozenForwardFootprint(model, kBatch);
+  EXPECT_EQ(frozen.weight_bytes, train.weight_bytes);
+  // Peak term: the widest activation is [16 x 8] f32.
+  EXPECT_EQ(frozen.activation_bytes, kBatch * 8 * sizeof(float));
+  EXPECT_TRUE(frozen.activation_bytes < train.activation_bytes);
+}
+
 }  // namespace

--- a/test/fuzz/binary_formats.cc
+++ b/test/fuzz/binary_formats.cc
@@ -4,6 +4,10 @@
 //   [0] LoadSmf                 — the model container reader
 //   [1] UpdateEngine::Initialize — the .seeu plan loader + validator
 //   [2] Dataset::LoadFromFile    — the corpus reader
+//   [3] LoadSmf + UpdateCompiler::Compile — the semantic layer past the
+//       loader (sema, parser, passes, driver), which consumes
+//       attacker-controlled loader-ACCEPTED models and would otherwise be
+//       fuzz-blind
 //
 // The first input byte selects the parser; the rest is the file image. The
 // contract under test: arbitrary bytes may be REJECTED but must never crash,
@@ -23,6 +27,7 @@
 #include <vector>
 
 #include "source/plan/update_types.h"
+#include "compiler/driver/update_compiler.h"
 #include "runtime/feeder/dataset.h"
 #include "runtime/engine/update_engine.h"
 #include "source/identity/hash.h"
@@ -46,7 +51,7 @@ void WriteBytes(const std::string& path, const uint8_t* data, size_t size) {
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   if (size < 1) return 0;
-  const uint8_t selector = data[0] % 3;
+  const uint8_t selector = data[0] % 4;
   const uint8_t* body = data + 1;
   const size_t body_size = size - 1;
 
@@ -86,6 +91,22 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
       WriteBytes(path, body, body_size);
       auto r = seeml::update_rt::Dataset::LoadFromFile(path);
       (void)r;
+      std::remove(path.c_str());
+      break;
+    }
+    case 3: {
+      // The contract under test: a loader-accepted model may be REFUSED by
+      // sema/parser/driver but must never crash them. Tiny batch and budget
+      // keep per-input compile cost bounded.
+      const std::string path = TempPath("smfc");
+      WriteBytes(path, body, body_size);
+      if (auto model = seeml::update::LoadSmf(path)) {
+        seeml::update::UpdateConfig config;
+        config.batch = 2;
+        config.memory_budget_bytes = 64u << 20;
+        auto compiled = seeml::update::UpdateCompiler(config).Compile(*model);
+        (void)compiled;
+      }
       std::remove(path.c_str());
       break;
     }

--- a/test/runtime/engine/update_engine_test.cc
+++ b/test/runtime/engine/update_engine_test.cc
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstring>
 #include <fstream>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -716,6 +717,61 @@ TEST(UpdateEngineTrain, TrainingIsBitwiseInvariantAcrossThreadCounts) {
             0);
   ASSERT_FALSE(persist_serial.empty());
   EXPECT_TRUE(persist_serial == persist_wide);
+}
+
+TEST(UpdateEngineMerge, RejectsNonFiniteMergeDeltas) {
+  // The training loop's loss guard reads the loss written BEFORE each
+  // step's backward + optimizer, so a gradient that overflows on the final
+  // executed step can poison the adapters unseen; RunMerge is the last
+  // line between a NaN delta and the committed model file.
+  UpdateConfig config = BaseConfig(kBatch);
+  SmfModel model = MakeMlp(kInDim, 10, 3, 1);
+  ASSERT_OK_AND_ASSIGN(CompiledUpdate compiled,
+                       UpdateCompiler(config).Compile(model));
+  UpdateEngine engine;
+  ASSERT_OK(engine.LoadFromMemory(compiled.plan.data(), compiled.plan.size()));
+
+  // Sanity: clean adapters merge fine.
+  ASSERT_OK(engine.RunMerge());
+
+  // Poison one element of the first adapter's A. B is zeros at step 0, and
+  // NaN * 0 is NaN, so the materialized delta carries the poison.
+  ASSERT_FALSE(compiled.adapters.empty());
+  seeml::testing::WriteArenaF32(engine, compiled.adapters[0].a_ref, 0,
+                                std::numeric_limits<float>::quiet_NaN());
+  EXPECT_ERROR_CONTAINS(engine.RunMerge(), "non-finite");
+}
+
+TEST(UpdateEngineLr, CosineWithWarmupBoundaryBehavior) {
+  // EffectiveLr scales every optimizer step and previously had no test at
+  // all: pin the warmup ramp, the warmup boundary, the cosine floor at the
+  // horizon, and the clamp past it.
+  UpdateConfig config = BaseConfig(kBatch);
+  config.optimizer.lr = 0.1f;
+  config.optimizer.lr_schedule = LrSchedule::kCosineWithWarmup;
+  config.optimizer.warmup_steps = 10;
+  config.optimizer.min_lr_factor = 0.1f;
+  config.default_steps = 100;
+  const std::vector<uint8_t> plan = CompilePlan(config);
+  ASSERT_FALSE(plan.empty());
+  UpdateEngine engine;
+  ASSERT_OK(engine.LoadFromMemory(plan.data(), plan.size()));
+
+  engine.SetStep(1);  // linear warmup: base * step / warmup
+  EXPECT_NEAR(engine.EffectiveLr(), 0.1f * 1.0f / 10.0f, 1e-7);
+  engine.SetStep(10);  // warmup boundary: exactly base
+  EXPECT_NEAR(engine.EffectiveLr(), 0.1f, 1e-7);
+  engine.SetStep(30);  // cosine decays monotonically between base and floor
+  const float mid_early = engine.EffectiveLr();
+  engine.SetStep(80);
+  const float mid_late = engine.EffectiveLr();
+  EXPECT_TRUE(mid_early > mid_late);
+  EXPECT_TRUE(mid_early < 0.1f);
+  EXPECT_TRUE(mid_late > 0.1f * 0.1f);
+  engine.SetStep(100);  // horizon: the floor
+  EXPECT_NEAR(engine.EffectiveLr(), 0.1f * 0.1f, 1e-6);
+  engine.SetStep(1000);  // past the horizon: clamped at the floor
+  EXPECT_NEAR(engine.EffectiveLr(), 0.1f * 0.1f, 1e-6);
 }
 
 }  // namespace

--- a/test/runtime/executor/kernels_test.cc
+++ b/test/runtime/executor/kernels_test.cc
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <vector>
 
 #include "runtime/executor/update_kernels.h"
@@ -683,6 +684,77 @@ TEST(Attention, BackwardPrimitivesMatchFiniteDifferences) {
   check(q, dq, 0);
   check(k2, dk, 1);
   check(v, dv, 2);
+}
+
+TEST(Loss, SingleClassSoftmaxIsExactlyCertain) {
+  // C = 1: every row's softmax is exactly 1 and the loss exactly 0 — the
+  // denominator always contains the max element's exp(0).
+  const size_t N = 3;
+  const std::vector<float> logits = {2.0f, -5.0f, 100.0f};
+  const std::vector<int32_t> labels = {0, 0, 0};
+  float loss = -1.0f;
+  std::vector<float> probs(N, 0.0f);
+  k::SoftmaxXEntFwd(logits.data(), labels.data(), &loss, probs.data(), N, 1);
+  EXPECT_EQ(loss, 0.0f);
+  for (float p : probs) EXPECT_EQ(p, 1.0f);
+}
+
+TEST(Loss, NanLogitPropagatesToTheLossSlot) {
+  // The engine's finite-loss guard depends on this: a NaN anywhere in the
+  // logits must surface in the loss, not be scrubbed by the max reduction.
+  const size_t N = 2, C = 3;
+  std::vector<float> logits(N * C, 0.5f);
+  logits[4] = std::numeric_limits<float>::quiet_NaN();
+  const std::vector<int32_t> labels = {0, 2};
+  float loss = 0.0f;
+  std::vector<float> probs(N * C);
+  k::SoftmaxXEntFwd(logits.data(), labels.data(), &loss, probs.data(), N, C);
+  EXPECT_TRUE(std::isnan(loss));
+}
+
+TEST(ClipNorm, ZeroGradientAndZeroCapAreExact) {
+  std::vector<float> g = {0.0f, 0.0f, 0.0f};
+  k::ClipNorm(g.data(), g.size(), 1.0f);  // ||g|| = 0: no 0/0, unchanged
+  for (float v : g) EXPECT_EQ(v, 0.0f);
+
+  std::vector<float> h = {3.0f, -4.0f};
+  k::ClipNorm(h.data(), h.size(), 0.0f);  // cap 0: scaled by exactly 0
+  for (float v : h) EXPECT_EQ(v, 0.0f);
+}
+
+TEST(LayerNorm, ZeroVarianceRowNormalizesToBeta) {
+  const size_t rows = 1, cols = 4;
+  const std::vector<float> x(cols, 7.25f);  // constant row: variance 0
+  const std::vector<float> gamma(cols, 2.0f);
+  const std::vector<float> beta = {0.5f, -1.0f, 3.0f, 0.0f};
+  std::vector<float> y(cols), mean(rows), rstd(rows);
+  k::LayerNormFwd(x.data(), gamma.data(), beta.data(), y.data(), mean.data(),
+                  rstd.data(), rows, cols);
+  // (x - mu) is exactly 0 per element, so y == beta bit-for-bit.
+  for (size_t c = 0; c < cols; ++c) EXPECT_EQ(y[c], beta[c]);
+}
+
+TEST(Gelu, BackwardStaysFiniteAtExtremeInputs) {
+  // In the saturated-tanh regime the sech^2 factor is a true zero while u'
+  // overflows; the dead term must be dropped, not evaluated as 0 * Inf.
+  const std::vector<float> x = {1e30f, -1e30f};
+  const std::vector<float> dy = {2.0f, 2.0f};
+  std::vector<float> dx(2);
+  k::GeluBwd(dy.data(), x.data(), dx.data(), 2);
+  EXPECT_EQ(dx[0], 2.0f);  // derivative saturates to 1
+  EXPECT_EQ(dx[1], 0.0f);  // derivative saturates to 0
+}
+
+TEST(Attention, SingleTokenSequenceIsIdentityOverV) {
+  // S = 1: the causal prefix is one element, P is exactly 1, and O copies V.
+  const size_t B = 2, S = 1, H = 2, d = 3, n = B * S * H * d;
+  const std::vector<float> q = RandnVector(n, 130);
+  const std::vector<float> k2 = RandnVector(n, 131);
+  const std::vector<float> v = RandnVector(n, 132);
+  std::vector<float> o(n), p(B * H * S * S);
+  k::AttnFwd(q.data(), k2.data(), v.data(), o.data(), p.data(), B, S, H, d);
+  for (float pv : p) EXPECT_EQ(pv, 1.0f);
+  for (size_t i = 0; i < n; ++i) EXPECT_EQ(o[i], v[i]);
 }
 
 TEST(Rope, GoldenValuesPinTheConvention) {


### PR DESCRIPTION
# Fix all 11 findings from the main-branch triple-lens review

Three adversarial review passes over merged main — **concurrency/lifecycle**, **numerics edge cases**, and **cross-pass interactions** — each instructed to refute its own candidates before reporting. The core paths held (the POSIX durability chain, the worker-pool memory orderings, the batch-pipeline handshake, all softmax/label/shape edges, the fuser/quantizer/grafter interaction matrix were all *proven* sound). These are the 11 findings that survived, each fixed here with a regression test where testable.

## Correctness
1. **Non-finite deltas were committable** — the train loop's finite-loss guard reads the loss written *before* each step's backward+optimizer, and the clamped xent/KL losses can never reach Inf, so a final-step gradient overflow (Inf → NaN via `ClipNorm`'s `Inf·0` or AdamW's `Inf/Inf`) poisoned the adapters unseen; without a validation split the NaN deltas were merged and committed to the model file. **`RunMerge` now proves every materialized delta finite** (test: poisoned adapter → `RunMerge` refuses).
2. **Denormal quantization scales** — subnormal-range weight tensors produced a denormal/zero scale: the pack's hoisted reciprocal became +Inf (everything clamps to ±127; zeros become `clamp(NaN)` → **UB on the int8 cast**) or the tensor silently dequantized to all zeros. The quantizer now skips such tensors (they stay f32) and the pack divides instead of multiplying by a reciprocal (test: subnormal tensor not selected).
3. **`GeluBwd` NaN at extreme inputs** — `0·Inf` in the saturated-tanh regime where the true derivative is 0 or 1; the dead term is now dropped (test: finite and exact at ±1e30).
4. **Dynamic `-1` beyond the leading dim** compiled into a sealed plan the runtime always rejects (zero-byte SIR bindings, wrapped `input_floats`). The reader now restricts `-1` to dim 0 and the driver rejects non-positive input/output widths (test: reader rejection).

## Durability — Windows brought up to the POSIX contract
5. **`DurableFileEdit::Commit`**: CRT `std::rename` cannot replace an existing destination (every repeat commit failed) and nothing fsynced — now `FlushFileBuffers` + `MoveFileEx(REPLACE_EXISTING|WRITE_THROUGH)`, mirroring `WriteFileDurable`'s own Win32 branch.
6. **`CommitLock`** was a silent no-op on Windows — now a real exclusion via `CreateFileA` with `dwShareMode=0` (crash-safe like flock).
7. **`Begin`'s sidecar copy** never checked the final deferred flush — a disk-full could rename a silently truncated model into place when the source hash is unbound. Now flushed and checked explicitly.
8. **Concurrent checkpoint saves** interleaved on a shared `.tmp` inode — now per-writer-unique sidecar names.

## Resilience & honesty
9. **`parallel_for`**: a throwing `std::thread` constructor permanently serialized the submitting thread (leaked TLS flag) and froze a half-populated pool — now RAII flag reset + top-up-and-degrade spawning (the job runs at whatever width exists; chunking is shape-based so results are identical).
10. **The step-0 feasibility gate refused provably feasible compiles**: teachers were charged the *sum* of activations though a frozen forward's transients die instantly and get slot-reused (16×+ over on deep teachers), and `--quantize-base` weights were counted at f32. New `EstimateFrozenForwardFootprint` (peak semantics) + ¼ weight scaling keep it a true lower bound (test: peak-not-sum semantics).
11. **The fuzzer was blind past `LoadSmf`** — a fourth selector arm now compiles loader-accepted models, covering sema/parser/driver (finding 4 was a live specimen of that blind class).

## Docs & coverage
- README scope section updated from the stale "seven op kinds (SMF v2)" claim to the shipped v3 transformer vocabulary, decoder exporter, and Metal G1a status.
- `EffectiveLr` promoted to the public introspection surface and its warmup/horizon/floor boundaries pinned — it scales every optimizer step and previously had **zero** test coverage.
- New kernel edge tests: C=1 softmax, NaN-logit propagation (the engine guard's contract), ClipNorm zero-gradient/zero-cap, zero-variance LayerNorm, S=1 attention.

All 25 suites green: **219 → 229 tests**.

Note: #41 is superseded (its commit reached main via #42) and can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
