### PR TITLE
Close the test-taxonomy gaps: 11 tests covering unmapped input spaces

### DIFF
--- a/test/compiler/frontend/model_io_test.cc
+++ b/test/compiler/frontend/model_io_test.cc
@@ -76,6 +76,65 @@ TEST(Smf, SaveLoadRoundTrip) {
   }
 }
 
+/// Assembles a minimal pre-v3 SMF file (no seq_len, no attr0) with one
+/// non-const input tensor and one single-input op of `kind` — the byte
+/// layout writers no longer emit, for exercising the per-version gates.
+std::vector<uint8_t> LegacySmfBytes(uint32_t version, uint8_t kind) {
+  std::vector<uint8_t> b;
+  auto u16 = [&](uint16_t v) {
+    for (int i = 0; i < 2; ++i) b.push_back((v >> (8 * i)) & 0xFF);
+  };
+  auto u32 = [&](uint32_t v) {
+    for (int i = 0; i < 4; ++i) b.push_back((v >> (8 * i)) & 0xFF);
+  };
+  auto u64 = [&](uint64_t v) {
+    for (int i = 0; i < 8; ++i) b.push_back((v >> (8 * i)) & 0xFF);
+  };
+  auto str = [&](const char* s) {
+    const size_t n = std::strlen(s);
+    u16(static_cast<uint16_t>(n));
+    b.insert(b.end(), s, s + n);
+  };
+  u32(kSmfMagic);
+  u32(version);
+  u32(1);  // num_tensors
+  u32(1);  // num_ops
+  str("x");
+  str("y");
+  str("x");           // tensor name
+  b.push_back(1);     // rank
+  b.push_back(0);     // flags: non-const
+  u64(static_cast<uint64_t>(int64_t{-1}));  // dynamic leading dim
+  u64(0);             // data_offset
+  u64(0);             // byte_size
+  b.push_back(kind);  // op kind
+  str("a");
+  b.push_back(1);  // num_inputs
+  str("x");
+  str("y");
+  return b;
+}
+
+TEST(Smf, KindCeilingIsPerVersion) {
+  // A file carrying a kind newer than its own version is corruption, not
+  // forward compatibility: v1 ended at Relu (2), v2 at LayerNorm (6).
+  ScopedTempDir dir;
+  const std::string path = dir.File("legacy.smf");
+
+  WriteAll(path, LegacySmfBytes(1, /*kind=*/3));  // Gelu inside a v1 file
+  EXPECT_ERROR_CONTAINS(LoadSmf(path), "unknown op kind");
+
+  WriteAll(path, LegacySmfBytes(2, /*kind=*/7));  // Add inside a v2 file
+  EXPECT_ERROR_CONTAINS(LoadSmf(path), "unknown op kind");
+
+  // The ceilings gate exactly at their own vocabulary: the newest v1 and
+  // v2 kinds still parse (the reader checks kinds, not arities).
+  WriteAll(path, LegacySmfBytes(1, /*kind=*/2));
+  EXPECT_OK(LoadSmf(path));
+  WriteAll(path, LegacySmfBytes(2, /*kind=*/6));
+  EXPECT_OK(LoadSmf(path));
+}
+
 TEST(Smf, LoadRejectsDynamicDimBeyondLeading) {
   // The dynamic (-1) marker binds to the compiled batch and is only
   // meaningful as the LEADING dim; anywhere else it would flow into the

--- a/test/runtime/custodian/custodian_test.cc
+++ b/test/runtime/custodian/custodian_test.cc
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <fstream>
 #include <numeric>
+#include <thread>
 #include <vector>
 
 #include "runtime/custodian/checkpoint.h"
@@ -94,6 +95,32 @@ TEST(DurableIo, StreamingFileHashMatchesContentHash64) {
   ASSERT_OK(WriteFileDurable(empty, nullptr, 0));
   ASSERT_OK_AND_ASSIGN(uint64_t empty_hash, HashFileContent(empty));
   EXPECT_EQ(empty_hash, seeml::update::ContentHash64(nullptr, 0));
+}
+
+TEST(DurableIo, ConcurrentWritersToOnePathYieldOneCompleteFile) {
+  // Bounded nondeterminism: two writers racing on the same destination may
+  // land in either order, but the surviving file must be ONE writer's
+  // complete payload — never an interleaving. (Per-writer-unique sidecar
+  // names are what rule out the shared-inode mix.)
+  ScopedTempDir dir;
+  const std::string path = dir.File("contended.bin");
+  const std::vector<uint8_t> a(256 * 1024, 0xAA);
+  const std::vector<uint8_t> b(256 * 1024, 0xBB);
+
+  for (int round = 0; round < 8; ++round) {
+    std::thread ta([&] {
+      auto r = WriteFileDurable(path, {{a.data(), a.size()}});
+      (void)r;
+    });
+    std::thread tb([&] {
+      auto r = WriteFileDurable(path, {{b.data(), b.size()}});
+      (void)r;
+    });
+    ta.join();
+    tb.join();
+    ASSERT_OK_AND_ASSIGN(std::vector<uint8_t> got, ReadFileBytes(path));
+    EXPECT_TRUE(got == a || got == b);
+  }
 }
 
 TEST(DurableIo, CommitLockIsExclusivePerTarget) {

--- a/test/runtime/executor/kernels_test.cc
+++ b/test/runtime/executor/kernels_test.cc
@@ -734,6 +734,41 @@ TEST(LayerNorm, ZeroVarianceRowNormalizesToBeta) {
   for (size_t c = 0; c < cols; ++c) EXPECT_EQ(y[c], beta[c]);
 }
 
+TEST(Activation, GeluAndSiluBackwardsMatchFiniteDifferences) {
+  // The smooth activations' backward kernels were pinned only through the
+  // compiled-plan system check; a direct central-difference unit test
+  // covers the input space (both signs, near zero, the |x| ~ 1-5 shoulder)
+  // without a compiler in the loop.
+  const size_t n = 9;
+  const std::vector<float> x = {-5.0f, -2.0f, -0.5f, -1e-3f, 0.0f,
+                                1e-3f, 0.5f,  2.0f,  5.0f};
+  const std::vector<float> dy(n, 1.0f);
+  const double eps = 1e-3;
+  std::vector<float> dx(n), fwd_p(n), fwd_m(n), xp(n), xm(n);
+
+  k::GeluBwd(dy.data(), x.data(), dx.data(), n);
+  for (size_t i = 0; i < n; ++i) {
+    xp = x; xm = x;
+    xp[i] += static_cast<float>(eps);
+    xm[i] -= static_cast<float>(eps);
+    k::GeluFwd(xp.data(), fwd_p.data(), n);
+    k::GeluFwd(xm.data(), fwd_m.data(), n);
+    EXPECT_NEAR(dx[i], static_cast<float>((fwd_p[i] - fwd_m[i]) / (2 * eps)),
+                2e-3);
+  }
+
+  k::SiluBwd(dy.data(), x.data(), dx.data(), n);
+  for (size_t i = 0; i < n; ++i) {
+    xp = x; xm = x;
+    xp[i] += static_cast<float>(eps);
+    xm[i] -= static_cast<float>(eps);
+    k::SiluFwd(xp.data(), fwd_p.data(), n);
+    k::SiluFwd(xm.data(), fwd_m.data(), n);
+    EXPECT_NEAR(dx[i], static_cast<float>((fwd_p[i] - fwd_m[i]) / (2 * eps)),
+                2e-3);
+  }
+}
+
 TEST(Gelu, BackwardStaysFiniteAtExtremeInputs) {
   // In the saturated-tanh regime the sech^2 factor is a true zero while u'
   // overflows; the dead term must be dropped, not evaluated as 0 * Inf.

--- a/test/runtime/feeder/dataset_test.cc
+++ b/test/runtime/feeder/dataset_test.cc
@@ -272,6 +272,36 @@ TEST(DatasetShuffle, IsSeededDeterministicAndCoversEachEpoch) {
   EXPECT_TRUE(xa == xb);
 }
 
+TEST(DatasetShuffle, RestoreReplaysAcrossMultipleEpochs) {
+  // RestoreServingPos promises an EXACT rewind even after the permutation
+  // has been redrawn several times: the replay reconstructs the snapshot's
+  // epoch from the shuffle origin. The single-epoch case is exercised by
+  // the batch pipeline's teardown; this pins the deep-replay path.
+  ASSERT_OK_AND_ASSIGN(Dataset data, MarkerDataset());
+  data.EnableShuffle(17);
+  const int64_t in_dim = 4;
+  std::vector<float> x(8 * in_dim);
+  std::vector<int32_t> l(8);
+  auto* lbytes = reinterpret_cast<uint8_t*>(l.data());
+
+  data.FillBatch(8, x.data(), lbytes);  // land mid-epoch-0
+  const Dataset::ServingPos snap = data.SaveServingPos();
+
+  // Consume 24 more batches: 64 samples at 8/batch = 8 batches per epoch,
+  // so this crosses two reshuffle boundaries past the snapshot's epoch.
+  std::vector<std::vector<float>> want;
+  for (int i = 0; i < 24; ++i) {
+    data.FillBatch(8, x.data(), lbytes);
+    want.push_back(x);
+  }
+
+  data.RestoreServingPos(snap);
+  for (int i = 0; i < 24; ++i) {
+    data.FillBatch(8, x.data(), lbytes);
+    EXPECT_TRUE(x == want[static_cast<size_t>(i)]);
+  }
+}
+
 TEST(DatasetSplit, HoldsOutTheTailDeterministically) {
   ASSERT_OK_AND_ASSIGN(Dataset data, MarkerDataset());
   ASSERT_OK_AND_ASSIGN(Dataset val, data.SplitValidation(0.25));

--- a/test/runtime/validator/validator_test.cc
+++ b/test/runtime/validator/validator_test.cc
@@ -72,6 +72,52 @@ TEST(PlanValidator, TransformerOpcodesAreVersionGated) {
   EXPECT_ERROR(ValidateInstruction(attn, 2048, kRodata, up::kSeeuVersion));
 }
 
+TEST(PlanValidator, RmsNormBackwardProvesTheStatsRef) {
+  // kRmsNormBwd carries the rstd cache as a REF in out[0]; its extent
+  // (rows floats) must be proven like any operand, not trusted.
+  up::UpdateInstruction bwd;
+  bwd.opcode = static_cast<uint16_t>(up::OpCode::kRmsNormBwd);
+  bwd.in[0] = up::MakeArenaRef(0);    // dy [4 x 8]
+  bwd.in[1] = up::MakeArenaRef(128);  // x
+  bwd.in[2] = up::MakeArenaRef(256);  // gamma [8]
+  bwd.in[3] = up::MakeArenaRef(512);  // dx (write)
+  bwd.out[0] = up::MakeArenaRef(768); // rstd [4]
+  bwd.out[1] = (uint64_t{4} << 32) | 8;
+  EXPECT_OK(ValidateInstruction(bwd, kArena, kRodata, up::kSeeuVersion));
+  bwd.out[0] = up::MakeArenaRef(kArena - 4);  // one float short of 4
+  EXPECT_ERROR(ValidateInstruction(bwd, kArena, kRodata, up::kSeeuVersion));
+}
+
+TEST(PlanValidator, AttentionBackwardExtentsAreProven) {
+  // kAttnDP writes the [B*H*S, S] probability-shaped dP; the write extent
+  // derives from the packed geometry and must stay inside the arena, and
+  // it must not alias the reads.
+  up::UpdateInstruction dp;
+  dp.opcode = static_cast<uint16_t>(up::OpCode::kAttnDP);
+  dp.in[0] = up::MakeArenaRef(0);    // dO [4 x 8] = 128 B
+  dp.in[1] = up::MakeArenaRef(128);  // v
+  dp.in[2] = up::MakeArenaRef(256);  // dP: B*H*S*S = 32 floats = 128 B
+  dp.out[0] = (uint64_t{1} << 32) | 4;  // B=1, S=4
+  dp.out[1] = (uint64_t{2} << 32) | 4;  // H=2, d=4
+  EXPECT_OK(ValidateInstruction(dp, kArena, kRodata, up::kSeeuVersion));
+  dp.in[2] = up::MakeArenaRef(kArena - 64);  // write range spills out
+  EXPECT_ERROR(ValidateInstruction(dp, kArena, kRodata, up::kSeeuVersion));
+  dp.in[2] = up::MakeArenaRef(64);  // write overlaps the dO read
+  EXPECT_ERROR(ValidateInstruction(dp, kArena, kRodata, up::kSeeuVersion));
+}
+
+TEST(PlanValidator, SoftmaxRowsBackwardOverflowIsRejected) {
+  // rows and cols each fill their 32-bit half; their product must go
+  // through MulOk — 2^32 * 2^32 wraps u64 to zero-ish garbage.
+  up::UpdateInstruction sm;
+  sm.opcode = static_cast<uint16_t>(up::OpCode::kSoftmaxRowsBwd);
+  sm.in[0] = up::MakeArenaRef(0);
+  sm.in[1] = up::MakeArenaRef(256);
+  sm.in[2] = up::MakeArenaRef(512);
+  sm.out[0] = (uint64_t{0xFFFFFFFFu} << 32) | 0xFFFFFFFFu;
+  EXPECT_ERROR(ValidateInstruction(sm, kArena, kRodata, up::kSeeuVersion));
+}
+
 TEST(PlanValidator, RopeRequiresEvenHeadWidth) {
   up::UpdateInstruction rope;
   rope.opcode = static_cast<uint16_t>(up::OpCode::kRopeFwd);

--- a/test/source/identity/hash_test.cc
+++ b/test/source/identity/hash_test.cc
@@ -86,6 +86,41 @@ TEST(ContentHash, SmallAndUnalignedSizes) {
   }
 }
 
+TEST(PlanSelfHash, EqualsContentHashOfTheZeroedBlobAtEveryOffsetClass) {
+  // The defining identity: PlanSelfHash(blob, at) must equal ContentHash64
+  // of a copy with the 8-byte field at `at` zeroed — including when the
+  // field STRADDLES a chunk boundary, the one code path where the patched
+  // copy must be split across two chunks' hashes. A multi-chunk blob makes
+  // that path real (single-chunk blobs never split the field).
+  const size_t size = 3 * seeml::update::kContentHashChunk + 123;
+  std::vector<uint8_t> blob(size);
+  for (size_t i = 0; i < size; ++i)
+    blob[i] = static_cast<uint8_t>(i * 2654435761u >> 13);
+  const size_t grain =
+      seeml::update::ParallelChunkGrain(size, seeml::update::kContentHashChunk);
+  ASSERT_TRUE(grain < size);  // genuinely multi-chunk
+
+  const size_t offsets[] = {0,
+                            5,
+                            grain - 7,  // straddles the first boundary
+                            grain - 1,  // straddles by a single byte
+                            grain,      // exactly at the boundary
+                            2 * grain - 3,
+                            size - sizeof(uint64_t)};
+  for (const size_t at : offsets) {
+    std::vector<uint8_t> zeroed = blob;
+    std::memset(zeroed.data() + at, 0, sizeof(uint64_t));
+    EXPECT_EQ(seeml::update::PlanSelfHash(blob.data(), size, at),
+              seeml::update::ContentHash64(zeroed.data(), size));
+  }
+  // And the seal is insensitive to what the field currently holds — the
+  // property Initialize relies on when verifying a sealed plan.
+  std::vector<uint8_t> resealed = blob;
+  std::memset(resealed.data() + grain - 4, 0xAB, sizeof(uint64_t));
+  EXPECT_EQ(seeml::update::PlanSelfHash(blob.data(), size, grain - 4),
+            seeml::update::PlanSelfHash(resealed.data(), size, grain - 4));
+}
+
 TEST(ContentHash, DistinctContentDistinctDigest) {
   auto a = DeterministicBytes(4096, /*seed=*/1);
   auto b = DeterministicBytes(4096, /*seed=*/2);

--- a/test/source/parallel/parallel_for_test.cc
+++ b/test/source/parallel/parallel_for_test.cc
@@ -155,6 +155,32 @@ TEST(ParallelFor, NestedCallsNeitherDeadlockNorDoubleExecute) {
     EXPECT_EQ(totals[o], inner * (inner - 1) / 2 + o * inner);
 }
 
+TEST(ParallelFor, ChunkExceptionIsRethrownAndThePoolSurvives) {
+  // The exception contract: a throwing chunk body stops new chunks, the
+  // loop retires fully, and the FIRST exception is rethrown on the calling
+  // thread — after which the pool must be fully usable. Untested until
+  // now, despite being the loop's only error path.
+  bool caught = false;
+  try {
+    seeml::update::ParallelFor(1 << 12, 1,
+                               [&](size_t, size_t, size_t chunk) {
+                                 if (chunk == 0)
+                                   throw std::runtime_error("chunk boom");
+                               });
+  } catch (const std::runtime_error& e) {
+    caught = std::string(e.what()) == "chunk boom";
+  }
+  EXPECT_TRUE(caught);
+
+  // The pool took no damage: full coverage on the very next call.
+  std::vector<int> hits(1 << 12, 0);
+  seeml::update::ParallelFor(hits.size(), 1,
+                             [&](size_t b, size_t e, size_t) {
+                               for (size_t i = b; i < e; ++i) ++hits[i];
+                             });
+  for (int h : hits) EXPECT_EQ(h, 1);
+}
+
 TEST(ParallelFor, BackToBackCallsReuseThePool) {
   ScopedThreads threads(4);
   // Many small jobs in a row: exercises the park/wake protocol under TSan

--- a/test/system/update_system_test.cc
+++ b/test/system/update_system_test.cc
@@ -30,6 +30,7 @@
 #include <limits>
 #include <random>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "compiler/driver/update_compiler.h"
@@ -612,6 +613,92 @@ TEST(UpdateSystem, QuantizedBaseTrainsAndCommitsWithoutBakingError) {
 // =============================================================================
 // 9. Poisoned corpus aborts the update
 // =============================================================================
+
+TEST(UpdateSystem, AdapterInitializationIsWellDistributed) {
+  // Bounds on the counter-based randn's output space: correct scale (std
+  // 1/sqrt(K)), near-zero mean, and no serial correlation between adjacent
+  // elements — the regression surface of the overlapping-counter defect,
+  // which coupled every sample's magnitude to its neighbor's angle while
+  // keeping the marginals exact. Deterministic (seeded), so exact-bound
+  // assertions cannot flake.
+  const int64_t in_dim = 64, hidden = 96, out_dim = 4, batch = 4;
+  SmfModel model = MakeMlp(in_dim, hidden, out_dim, 21);
+  UpdateConfig config = BaseConfig(batch);
+  config.lora.rank = 16;
+  ASSERT_OK_AND_ASSIGN(CompiledUpdate compiled,
+                       UpdateCompiler(config).Compile(model));
+  UpdateEngine engine;
+  ASSERT_OK(engine.LoadFromMemory(compiled.plan.data(), compiled.plan.size()));
+
+  // w1's adapter A is [in_dim, rank] randn at std 1/sqrt(in_dim).
+  const ParamDebugInfo* a_param = nullptr;
+  for (const auto& p : compiled.params)
+    if (p.id == "w1.lora_A") a_param = &p;
+  ASSERT_NE(a_param, nullptr);
+  const size_t n = a_param->count;
+  ASSERT_EQ(n, static_cast<size_t>(in_dim * 16));
+
+  std::vector<double> v(n);
+  for (size_t i = 0; i < n; ++i)
+    v[i] = ReadArenaF32(engine, a_param->param_ref, i);
+  double sum = 0.0, sq = 0.0, lag = 0.0;
+  for (size_t i = 0; i < n; ++i) {
+    sum += v[i];
+    sq += v[i] * v[i];
+  }
+  const double mean = sum / static_cast<double>(n);
+  const double var = sq / static_cast<double>(n) - mean * mean;
+  const double expect_std = 1.0 / std::sqrt(static_cast<double>(in_dim));
+  for (size_t i = 0; i + 1 < n; ++i)
+    lag += (v[i] - mean) * (v[i + 1] - mean);
+  const double lag1 = lag / (static_cast<double>(n) * var);
+
+  // 5-sigma-style bounds at n = 1024: mean within 5*std/sqrt(n), std
+  // within 15%, |lag-1 autocorrelation| under 5/sqrt(n).
+  EXPECT_TRUE(std::fabs(mean) < 5.0 * expect_std / std::sqrt(1.0 * n));
+  EXPECT_TRUE(std::fabs(std::sqrt(var) / expect_std - 1.0) < 0.15);
+  EXPECT_TRUE(std::fabs(lag1) < 5.0 / std::sqrt(1.0 * n));
+}
+
+TEST(UpdateSystem, ConcurrentEnginesShareThePoolDeterministically) {
+  // Bounded nondeterminism at the process level: two engines training in
+  // parallel threads share the global worker pool and each runs its own
+  // feeder thread, yet every engine's result must be bitwise identical to
+  // its serial run — chunk geometry depends on problem shape, never on
+  // who else is submitting.
+  const int64_t batch = 8;
+  auto run = [&](uint64_t model_seed, uint64_t data_seed,
+                 std::vector<uint8_t>* persist_out) {
+    SmfModel model = MakeMlp(6, 12, 2, model_seed);
+    UpdateConfig config = BaseConfig(batch);
+    config.optimizer.lr = 5e-3f;
+    auto compiled = UpdateCompiler(config).Compile(model);
+    if (!compiled) return false;
+    UpdateEngine engine;
+    if (!engine.LoadFromMemory(compiled->plan.data(), compiled->plan.size()))
+      return false;
+    auto data = MakeClassificationData(128, 6, data_seed);
+    if (!data) return false;
+    if (!engine.Train(*data, 30, Quiet())) return false;
+    persist_out->assign(engine.arena(),
+                        engine.arena() + engine.header().persistent_size);
+    return true;
+  };
+
+  std::vector<uint8_t> serial_a, serial_b, threaded_a, threaded_b;
+  ASSERT_TRUE(run(31, 41, &serial_a));
+  ASSERT_TRUE(run(32, 42, &serial_b));
+
+  bool ok_a = false, ok_b = false;
+  std::thread ta([&] { ok_a = run(31, 41, &threaded_a); });
+  std::thread tb([&] { ok_b = run(32, 42, &threaded_b); });
+  ta.join();
+  tb.join();
+  ASSERT_TRUE(ok_a);
+  ASSERT_TRUE(ok_b);
+  EXPECT_TRUE(threaded_a == serial_a);
+  EXPECT_TRUE(threaded_b == serial_b);
+}
 
 TEST(UpdateSystem, NonFiniteLossAbortsTheUpdate) {
   const int64_t in_dim = 5, hidden = 8, out_dim = 3, batch = 8;


### PR DESCRIPTION
# Test-taxonomy audit: close the unmapped input spaces (+11 tests)

Audit of `test/` against the three test roles the tree is organized around — **unit** (function input/output space coverage), **regression** (pinned deterministic behavior), **integration** (bounded behavior of nondeterministic elements). Stacked on #44.

## The audit's verdict
Coverage is broad and well-partitioned (one suite per module, mirroring the source tree; 229 tests pre-PR). The genuine holes, now closed:

### Unit — input spaces with zero coverage
| gap | new test |
|---|---|
| `PlanSelfHash` had **no tests** (only `ContentHash`), including the straddling-chunk patch path | `PlanSelfHash.EqualsContentHashOfTheZeroedBlobAtEveryOffsetClass` — identity vs zeroed-copy `ContentHash64` at 7 offset classes incl. boundary-straddling, + seal insensitivity |
| per-version SMF kind ceilings (fixed in #44's predecessor) untested | `Smf.KindCeilingIsPerVersion` — hand-assembled v1/v2-layout files; wrong-version kinds rejected, own-version kinds parse |
| v6 backward opcodes had no validator negatives | `RmsNormBackwardProvesTheStatsRef`, `AttentionBackwardExtentsAreProven`, `SoftmaxRowsBackwardOverflowIsRejected` |
| GeluBwd/SiluBwd never unit-tested against their forwards | `Activation.GeluAndSiluBackwardsMatchFiniteDifferences` (9-point input sweep) |

### Regression — deterministic behavior unpinned
| gap | new test |
|---|---|
| `RestoreServingPos` deep replay (multi-epoch rewind) only exercised implicitly at 1 epoch | `DatasetShuffle.RestoreReplaysAcrossMultipleEpochs` — snapshot, cross two reshuffles, restore, 24-batch bitwise replay |
| `counter_randn`'s distribution (the overlapping-counter regression surface) unpinned | `UpdateSystem.AdapterInitializationIsWellDistributed` — scale/mean/lag-1 bounds on a 1024-element LoRA A, seeded (cannot flake) |

### Integration — concurrency claims that were doctrine, not tests
| gap | new test |
|---|---|
| "chunk geometry never depends on who else is submitting" had no cross-engine test | `UpdateSystem.ConcurrentEnginesShareThePoolDeterministically` — two engines training in parallel threads produce persist segments **bitwise identical** to their serial runs |
| racing durable writers (the #44 unique-sidecar fix) untested | `DurableIo.ConcurrentWritersToOnePathYieldOneCompleteFile` — 8 rounds, survivor is always one complete payload |
| `ParallelFor`'s only error path (throwing chunk body) untested | `ParallelFor.ChunkExceptionIsRethrownAndThePoolSurvives` — first-exception rethrow + full pool coverage afterward |

## Noted, deliberately not covered here
- The CLI binaries (`seeml-update-compile`, `seeml-seeu-dump`) have no test harness — they'd need process-spawning tests; worth a follow-up decision.
- `export_model.py` has no Python-side tests (no Python in CI).
- Windows durability branches are compile-time untestable from this host; the fixes in #44 follow the documented `WriteFileDurable` pattern that is tested on POSIX.

All 25 suites green: **229 → 240 tests**, every addition passing on its first full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
