### PR TITLE
Define CI: per-diff invariant gates (matrix, determinism widths, ASan/UBSan, fuzz) + nightly TSan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,158 @@
+# =============================================================================
+# CI — the per-diff invariant gate. Every pull request (and every push to
+# main) must re-prove the three properties the project is built around:
+#
+#   correctness   build+test on every supported toolchain, ASan+UBSan over
+#                 the full suite set, and a bounded fuzz pass over the four
+#                 untrusted-input arms (SMF / SEEU / SDS / compile-of-SMF)
+#   determinism   the bitwise-invariance suites re-run under SEEML_THREADS
+#                 in {1, 3, 8}, so every "same bits at any width" assertion
+#                 executes against genuinely different worker-pool shapes
+#   boundedness   the seeded distribution-bound and concurrency-race tests
+#                 run in every matrix cell; the slow ThreadSanitizer pass
+#                 over the same races lives in nightly.yml
+#
+# The suites themselves carry the assertions; CI's job is to run them on
+# configurations a developer machine does not (other OS/compilers,
+# sanitizers, varied pool widths) and to refuse the merge when any fails.
+# =============================================================================
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # --- Correctness: the supported-toolchain matrix ---------------------------
+  # README promises clang or gcc, CMake optional: the shell driver is the
+  # canonical build here. macOS additionally exercises the ObjC++ Metal
+  # harness (the suite degrades to a note when the runner has no device).
+  build-and-test:
+    name: test (${{ matrix.os }}, ${{ matrix.cxx }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, cxx: g++ }
+          - { os: ubuntu-latest, cxx: clang++ }
+          - { os: macos-latest, cxx: clang++ }
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    env:
+      CXX: ${{ matrix.cxx }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build (shell driver, no CMake)
+        run: sh build/build.sh
+      - name: Run every suite
+        run: |
+          fail=0
+          for t in build/seeml_*_test; do
+            echo "== $t"
+            "$t" || fail=1
+          done
+          exit $fail
+
+  # --- Determinism: identical bits at every pool width -----------------------
+  # SEEML_THREADS pins the global worker pool. The bitwise assertions inside
+  # the suites (plan bytes, persist segments, kernel outputs, hashes) then
+  # execute serially, at an odd width, and wide — any scheduling-dependent
+  # numeric would trip at least one width.
+  determinism:
+    name: determinism (widths 1/3/8)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CXX: clang++
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: sh build/build.sh
+      - name: Run all suites at each width
+        run: |
+          fail=0
+          for w in 1 3 8; do
+            echo "==== SEEML_THREADS=$w"
+            for t in build/seeml_*_test; do
+              SEEML_THREADS=$w "$t" > /tmp/out.log 2>&1 || {
+                echo "FAILED at width $w: $t"
+                cat /tmp/out.log
+                fail=1
+              }
+            done
+          done
+          exit $fail
+
+  # --- Correctness: Address + UndefinedBehavior sanitizers -------------------
+  # The bug class the reviews kept surfacing (e.g. a float->int8 cast of
+  # clamp(NaN)) is exactly what UBSan turns from silent corruption into a
+  # red build. Uses the CMake path, which carries the sanitizer plumbing.
+  asan-ubsan:
+    name: ASan + UBSan
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CXX: clang++
+      ASAN_OPTIONS: strict_string_checks=1:detect_stack_use_after_return=1
+      UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: >
+          cmake -S . -B build-san
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          -DSEEML_SANITIZE="address;undefined"
+      - name: Build
+        run: cmake --build build-san -j "$(nproc)"
+      - name: Test
+        run: ctest --test-dir build-san --output-on-failure
+
+  # --- Correctness: bounded fuzz over the untrusted-input arms ---------------
+  # 90 seconds per PR is a smoke pass, not a campaign (nightly runs the long
+  # one): it still catches shallow regressions in the reader/validator
+  # rejection paths that a hand-written test didn't anticipate.
+  fuzz-smoke:
+    name: fuzz (90s smoke)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      CXX: clang++
+      CC: clang
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: cmake -S . -B build-fuzz -DSEEML_FUZZ=ON
+      - name: Build harness
+        run: cmake --build build-fuzz -j "$(nproc)" --target seeml_fuzz_formats
+      - name: Fuzz
+        run: |
+          mkdir -p corpus
+          ./build-fuzz/seeml_fuzz_formats -max_total_time=90 \
+            -print_final_stats=1 corpus
+      - name: Upload crashes
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crashes
+          path: |
+            crash-*
+            corpus
+          if-no-files-found: ignore
+
+  # --- Correctness: the Python exporter at least parses ----------------------
+  # Torch is deliberately not installed (heavy; the exporter's torch imports
+  # are function-local): this gates syntax and top-level import errors.
+  exporter-syntax:
+    name: exporter syntax
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Byte-compile
+        run: python3 -m py_compile tool/export_model.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,73 @@ jobs:
             corpus
           if-no-files-found: ignore
 
+  # --- Correctness: the product contract, end to end -------------------------
+  # The strongest claim in the docs — "the emitted package builds and runs
+  # with no access to this repository" — exercised for real: PyTorch export
+  # -> compile -> the package's own generated build.sh -> model_update
+  # training, gating, and committing on-device style. Then the determinism
+  # invariant at the artifact level: a fully serial re-run must commit a
+  # BITWISE-identical model. Outcome-robust: if the seeded demo's gate
+  # rejects (exit 3), the run is retried with --force — the invariants
+  # under test are build/run/commit/determinism, not the demo's luck.
+  e2e-package:
+    name: e2e (export -> compile -> package -> update)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CXX: clang++
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install CPU torch for the exporter
+        run: pip install --index-url https://download.pytorch.org/whl/cpu torch numpy
+      - name: Export the demo model + corpus
+        run: python3 tool/export_model.py --demo out/
+      - name: Build the compiler
+        run: sh build/build.sh
+      - name: Compile the plan and build the emitted package
+        run: |
+          ./build/seeml-update-compile --source out/model.smf --out out/pkg \
+            --data-batch 16 --loss xent --lora-rank 8 --lr 5e-3 --steps 300 \
+            --report out/pkg/report.json --build
+          test -x out/pkg/model_update
+      - name: Verify the plan seal with the disassembler
+        run: ./build/seeml-seeu-dump out/pkg/update_plan.seeu | grep -q "(verified)"
+      - name: Run the update (parallel), tolerating a gate rejection
+        run: |
+          set +e
+          out/pkg/model_update --model out/model.smf --data out/corpus.sds \
+            --out out/updated.smf --seed 7 --val-frac 0.1
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "gate: improved and committed"
+            echo "E2E_FORCE=" >> "$GITHUB_ENV"
+          elif [ "$rc" -eq 3 ]; then
+            echo "gate: rejected — exercising the commit path with --force"
+            out/pkg/model_update --model out/model.smf --data out/corpus.sds \
+              --out out/updated.smf --seed 7 --val-frac 0.1 --force
+            echo "E2E_FORCE=--force" >> "$GITHUB_ENV"
+          else
+            echo "model_update failed with a real error ($rc)"
+            exit "$rc"
+          fi
+          test -s out/updated.smf
+      - name: Serial re-run commits a bitwise-identical model
+        run: |
+          # The gate's verdict is deterministic (same data, seed, and plan;
+          # thread count never changes bits), so the parallel run's verdict
+          # carries over — a divergence would itself be a determinism bug
+          # and correctly fails this step.
+          SEEML_THREADS=1 out/pkg/model_update --model out/model.smf \
+            --data out/corpus.sds --out out/updated_serial.smf \
+            --seed 7 --val-frac 0.1 ${E2E_FORCE}
+          cmp out/updated.smf out/updated_serial.smf
+          echo "serial and parallel commits are bitwise identical"
+
   # --- Correctness: the Python exporter at least parses ----------------------
   # Torch is deliberately not installed (heavy; the exporter's torch imports
   # are function-local): this gates syntax and top-level import errors.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+# =============================================================================
+# CodeQL — GitHub's semantic static analysis over the C++ tree, the
+# correctness layer the test suites cannot provide: dataflow queries for
+# memory-safety, integer-conversion, and taint-style defects reachable
+# through paths no fixture exercises. Complements ci.yml's dynamic
+# sanitizers (ASan/UBSan see only executed paths; CodeQL sees the rest).
+#
+# Manual build mode: CodeQL traces the canonical shell driver, so the
+# database contains exactly the translation units the product ships.
+# =============================================================================
+
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "42 8 * * 1"  # weekly full pass, independent of PR traffic
+
+jobs:
+  analyze:
+    name: analyze (c-cpp)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: c-cpp
+          queries: security-and-quality
+      - name: Build (traced)
+        run: sh build/build.sh
+        env:
+          CXX: clang++
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:c-cpp"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,74 @@
+# =============================================================================
+# Nightly — the invariant checks too slow (or too statistical) to gate every
+# pull request, run daily against main and on demand:
+#
+#   ThreadSanitizer   the whole suite set under TSan — the concurrency
+#                     integration tests (racing durable writers, concurrent
+#                     engines on the shared pool, pipeline teardown, chunk
+#                     exceptions) execute with the race detector watching,
+#                     turning "bounded behavior" from assertion into proof
+#   extended fuzz     15 minutes over the four untrusted-input arms, with
+#                     the corpus carried between runs via the actions cache
+#
+# A nightly failure is a regression on main itself, not on a diff — treat
+# it with the same severity as a red PR.
+# =============================================================================
+
+name: Nightly
+
+on:
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+
+jobs:
+  tsan:
+    name: ThreadSanitizer (full suites)
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      CXX: clang++
+      TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: >
+          cmake -S . -B build-tsan
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          -DSEEML_SANITIZE=thread
+      - name: Build
+        run: cmake --build build-tsan -j "$(nproc)"
+      - name: Test under TSan
+        run: ctest --test-dir build-tsan --output-on-failure
+
+  fuzz-extended:
+    name: fuzz (15 min, cached corpus)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CXX: clang++
+      CC: clang
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore corpus
+        uses: actions/cache@v4
+        with:
+          path: corpus
+          key: fuzz-corpus-${{ github.run_id }}
+          restore-keys: fuzz-corpus-
+      - name: Configure
+        run: cmake -S . -B build-fuzz -DSEEML_FUZZ=ON
+      - name: Build harness
+        run: cmake --build build-fuzz -j "$(nproc)" --target seeml_fuzz_formats
+      - name: Fuzz
+        run: |
+          mkdir -p corpus
+          ./build-fuzz/seeml_fuzz_formats -max_total_time=900 \
+            -print_final_stats=1 corpus
+      - name: Upload crashes
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-fuzz-crashes
+          path: crash-*
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Read in this order:
 | [docs/runtime.md](docs/runtime.md) | on-device runtime architecture: engine, feeder, executor, validator, custodian |
 | [docs/formats.md](docs/formats.md) | the binary formats: SMF models, SDS datasets, SEEU plans, SEKP checkpoints |
 | [test/README.md](test/README.md) | the test tree, the in-repo SeeTest harness, and how suites mirror the code |
+| [docs/workflows.md](docs/workflows.md) | continuous integration from first principles: what a workflow is, and what each of SeeML's asserts |
 | [docs/roadmap.md](docs/roadmap.md) | the remaining architecture-review projects, scoped and sequenced |
 | [docs/journey.md](docs/journey.md) | how the project got here: from a C compiler to an ML update compiler |
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,418 @@
+# Workflows — An Introduction from First Principles
+
+*This is SeeML's continuous integration. Let's take it from the top.*
+
+You've just changed some code. It compiles on your machine. The tests pass
+on your machine. You open a pull request, someone merges it, and three days
+later a teammate on Linux discovers the build is broken, a kernel produces
+different bits at eight threads than at one, and a fuzzer-shaped user has
+crashed the model loader with a file your tests never imagined.
+
+Every one of those failures was *detectable at the moment of the merge*.
+Nobody detected them, because detection was a human's job, and humans
+forget. The entire idea of this document is one sentence:
+
+> **A workflow is a program whose job is to run your other programs'
+> checks, every time, so that no human has to remember to.**
+
+That's it. Everything else is mechanics. But the mechanics matter, so
+let's build them up from nothing.
+
+---
+
+## Part 0 — What problem are we actually solving?
+
+SeeML makes three promises, stated all over its documentation:
+
+1. **Correctness** — a compiled update plan does what the math says: the
+   gradients match calculus, the bounds checks hold against hostile
+   bytes, the committed model is the trained model.
+2. **Determinism** — the same plan, data, and seed produce the *same
+   bits* at any thread count, on any run. Not "approximately the same" —
+   bitwise identical.
+3. **Boundedness** — where behavior genuinely varies (two writers racing
+   to a file, a fuzzer throwing garbage, threads interleaving), the
+   *envelope* of outcomes is still guaranteed: one complete file wins,
+   the loader rejects instead of crashing, races never corrupt.
+
+Here's the thing about promises like these: they decay. Every diff is an
+opportunity to silently break one. The test suites in `test/` are the
+*assertions* of these promises — 240 of them at last count — but a test
+that nobody runs is documentation, not verification.
+
+So we need a machine that runs them. On every change. On computers that
+are *not* your laptop, because your laptop is one operating system, one
+compiler, one CPU count, and the promises are supposed to hold everywhere.
+
+That machine is GitHub Actions, and the programs you write for it are
+called **workflows**.
+
+---
+
+## Part 1 — What is a workflow, mechanically?
+
+A workflow is a YAML file in the magic directory `.github/workflows/`.
+When certain **events** happen in the repository — someone opens a pull
+request, pushes to `main`, or a scheduled time arrives — GitHub reads
+these files and executes them. SeeML has three:
+
+```
+.github/workflows/
+  ci.yml        runs on every pull request and push to main
+  nightly.yml   runs every night, and on demand
+  codeql.yml    runs on every pull request, push, and weekly
+```
+
+Let's dissect the anatomy with a real (simplified) excerpt from `ci.yml`:
+
+```yaml
+name: CI                        # what the badge and the checks tab call it
+
+on:                             # WHEN does this run?
+  pull_request:                 #   every time a PR is opened or updated
+  push:
+    branches: [main]            #   and every push to main
+
+jobs:                           # WHAT runs? A set of named jobs...
+  build-and-test:               #   ...this one is called build-and-test
+    runs-on: ubuntu-latest      #   on a fresh Linux virtual machine
+    steps:                      #   as a sequence of steps:
+      - uses: actions/checkout@v4      # step 1: clone the repo
+      - name: Build
+        run: sh build/build.sh         # step 2: run a shell command
+      - name: Run every suite
+        run: |
+          for t in build/seeml_*_test; do "$t" || exit 1; done
+```
+
+Five concepts, and you know them all already in other forms:
+
+- An **event** (`on:`) is a trigger — the moment the machine wakes up.
+  Think of an interrupt handler, or a database trigger.
+- A **job** is an independent unit of work that gets its own **runner** —
+  a disposable virtual machine, born clean, destroyed after. Jobs run *in
+  parallel* with each other by default. That's why SeeML's CI is split
+  into six jobs instead of one long script: six machines working at once,
+  and when one fails you know *which promise* broke from the job's name
+  alone.
+- A **step** is one command (or one reusable **action**, like
+  `actions/checkout` — someone else's packaged steps) inside a job.
+  Steps run *in sequence*, and the job stops at the first failure.
+- A **matrix** (you'll see it below) is a for-loop over jobs: write the
+  job once, run it per operating system × compiler combination.
+- The **exit code** is the entire verdict. Zero means the step passed;
+  anything else fails the step, the job, and the green checkmark. This
+  is why every test binary, every `cmp`, every `grep -q` in these
+  workflows matters — each one is a proposition, and its exit code is
+  the proof or the counterexample.
+
+One more idea and the mechanics are done. This line appears near the top
+of `ci.yml`:
+
+```yaml
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+If you push twice in quick succession, the first run is now testing dead
+code. This says: cancel it, test the newest. The `${{ ... }}` syntax is
+the workflow's variable interpolation — here, the branch name — so each
+branch gets its own cancellation group.
+
+That's the whole language. Now the interesting part: *what do we choose
+to check?*
+
+---
+
+## Part 2 — Mapping promises to jobs
+
+Recall the three promises. Here is the entire CI surface of SeeML, one
+row per job, and — this is the design — **every row exists to guard a
+named promise**:
+
+| workflow | job | promise guarded |
+|---|---|---|
+| ci.yml | `build-and-test` (×3 toolchains) | correctness, everywhere |
+| ci.yml | `determinism` (widths 1/3/8) | determinism |
+| ci.yml | `asan-ubsan` | correctness (memory / UB) |
+| ci.yml | `fuzz-smoke` | boundedness (hostile input) |
+| ci.yml | `e2e-package` | correctness + determinism of the *product* |
+| ci.yml | `exporter-syntax` | correctness (the Python edge) |
+| nightly.yml | `tsan` | boundedness (races) |
+| nightly.yml | `fuzz-extended` | boundedness (hostile input, deeper) |
+| codeql.yml | `analyze` | correctness (paths the tests never run) |
+
+If a job goes red, the *name of the job* tells you which promise your
+diff endangered. That is not an accident; that is the specification.
+
+Let's take them one at a time.
+
+---
+
+## Part 3 — `ci.yml`: the per-diff gate
+
+### 3.1 `build-and-test` — does it even work, everywhere?
+
+```yaml
+strategy:
+  matrix:
+    include:
+      - { os: ubuntu-latest, cxx: g++ }
+      - { os: ubuntu-latest, cxx: clang++ }
+      - { os: macos-latest, cxx: clang++ }
+```
+
+The README promises "a C++23 compiler (clang or gcc)". A promise about
+*two compilers and two operating systems* cannot be kept by testing one
+of each — so the matrix expands this job into three, each on its own
+fresh machine, each running the canonical build (`build/build.sh`, plain
+`sh`, no CMake required) and then all 25 test suites.
+
+Why does multi-compiler matter for *correctness*, not just convenience?
+Because compilers disagree about exactly the things that hide bugs:
+which warnings fire (the build uses `-Werror`, so a warning *is* a
+failure), how aggressively undefined behavior is exploited, how floats
+are contracted. Code that is correct C++ passes both; code that merely
+*happens to work* on clang often does not survive gcc, and you want to
+learn that at the pull request, not in a user's bug report.
+
+The macOS cell earns its keep twice: it also compiles the Objective-C++
+Metal GPU harness (`runtime/executor/metal_gemm.mm`), which exists only
+on Apple platforms. One subtlety worth internalizing: GitHub's macOS
+runners are virtual machines that may expose **no Metal device**. The
+test suite was written for exactly this: with no device it prints a note
+and passes vacuously. A check that cannot run *must* say so and step
+aside — a skipped check that pretends to be a passed check is how CI
+lies to you.
+
+### 3.2 `determinism` — same bits at every width
+
+Here is the job in one breath: build once, then run **every suite three
+times** — under `SEEML_THREADS=1`, `=3`, and `=8`.
+
+To see why, you need one fact about SeeML's design (the full story is in
+[runtime.md](runtime.md)): parallel work is chunked by *problem shape*,
+never by thread count. The thread count decides who computes each chunk,
+never what the chunks are — so every result is supposed to be bitwise
+identical whether one thread ran or eight did.
+
+Many of the 240 tests assert exactly that ("compile this plan twice,
+compare bytes"; "train serially and widely, compare persistent
+segments"). But an assertion inside a program can only test the
+configurations the program was run in. This job supplies the
+configurations: fully serial (width 1 — no worker thread is ever
+created, the degenerate case), an *odd* width (3 — chunk counts that
+don't divide evenly, the awkward case), and wide (8 — real contention).
+A diff that sneaks any scheduling-dependent numeric into a kernel —
+an accumulation order that depends on which thread got there first —
+trips at least one width.
+
+Ask yourself: why not width 2 and 4? Because 3 is the interesting one.
+Even widths tend to divide chunk counts neatly; oddness exercises the
+remainders. When you design a matrix, you are choosing *which* points of
+a space to sample — sample the awkward points.
+
+### 3.3 `asan-ubsan` — the bugs that don't crash
+
+Some bugs are polite enough to crash. The dangerous ones aren't: a read
+one byte past a buffer usually *works*; casting `NaN` to `int8_t` is
+undefined behavior that usually *produces some number*. Your tests pass.
+The corruption ships.
+
+**Sanitizers** are compiler modes that plant tripwires: AddressSanitizer
+(ASan) shadows every allocation and faults on the first out-of-bounds
+touch; UndefinedBehaviorSanitizer (UBSan) instruments every operation
+the C++ standard leaves undefined and reports the violation at the
+moment it happens. The cost is a few× slowdown, which is why this is its
+own job rather than the default build.
+
+This job builds the whole tree with both (`-DSEEML_SANITIZE=
+"address;undefined"`, plumbing the repo's CMake already carries) and
+runs all suites. The environment line `UBSAN_OPTIONS: halt_on_error=1`
+is load-bearing: by default UBSan *warns and continues*, and a warning
+nobody reads is that lying-CI problem again. Halting makes the exit code
+carry the verdict.
+
+Historical note, because it's instructive: a code review of this project
+found a real `int8_t(std::clamp(NaN, ...))` — silent corruption on
+every compiler, invisible to every test, and *precisely* the species
+UBSan converts into a red build. This job exists so that class of bug
+can never return quietly.
+
+### 3.4 `fuzz-smoke` — the inputs you didn't think of
+
+Every test you write is an input you thought of. The model loader, the
+plan loader, and the dataset loader parse *files* — and files come from
+outside, where nobody thinks the way you do.
+
+A **fuzzer** generates inputs by mutation, guided by coverage: it
+watches which branches each input reaches and mutates the inputs that
+reached new ones. Over time it discovers, mechanically, the malformed
+files that your hand-written rejection tests missed. SeeML's harness
+(`test/fuzz/binary_formats.cc`) exposes four attack surfaces — the SMF
+model reader, the SEEU plan loader, the SDS dataset reader, and the
+compiler running on loader-accepted models — and the contract under
+test is absolute: *arbitrary bytes may be rejected but must never
+crash, overflow, or over-read.*
+
+Per pull request this job runs **90 seconds** of fuzzing. Ninety seconds
+is not a security audit — it is a smoke test that catches *shallow*
+regressions (an unguarded length field, a reordered bounds check) while
+staying affordable on every diff. Depth is the nightly's job (Part 4).
+If it ever fails, the crashing input itself is uploaded as an artifact,
+so the counterexample lands in your hands, reproducible.
+
+### 3.5 `e2e-package` — the product contract, literally
+
+Everything so far tests the *repository*. But SeeML's actual product is
+a thing the repository emits: a self-contained package that must build
+and run **with no access to this repository at all** (that's the
+vendoring contract in [runtime.md](runtime.md)). Until this job, that
+claim was tested structurally — "the files are present" — never
+operationally.
+
+This job performs the entire documented user journey, for real:
+
+1. `pip install torch` (CPU build) and export the demo model + corpus
+   with `tool/export_model.py --demo` — the Python/C++ format seam,
+   exercised end to end.
+2. Compile the plan and emit the package; `--build` then compiles the
+   package *using its own generated `build.sh`*, exactly as a user
+   would on a device.
+3. Verify the plan's integrity seal with the disassembler
+   (`grep -q "(verified)"` — remember, exit codes are propositions).
+4. Run `model_update`: load, validate, train, gate, merge, commit.
+5. Run it **again**, fully serial (`SEEML_THREADS=1`), and `cmp` the two
+   committed models. They must be *bitwise identical* — the determinism
+   promise, asserted not on a kernel or a test fixture but on the final
+   artifact a user would deploy.
+
+One design decision deserves a highlight. The demo's regression gate
+might (deterministically) decide the training didn't improve and refuse
+to commit — exit code 3, which is *correct behavior*, not a bug. The
+job distinguishes it: exit 0 proceeds, exit 3 retries with `--force`
+(because the invariant under test is build/run/commit/determinism, not
+the demo's convergence), and anything else fails loudly. When you write
+checks, decide up front which outcomes are failures and which are
+merely *answers* — conflating them produces flaky CI, and flaky CI
+trains humans to ignore red, which destroys the entire enterprise.
+
+### 3.6 `exporter-syntax` — the cheapest possible tripwire
+
+`python3 -m py_compile tool/export_model.py`. Five seconds. It catches
+exactly one class of regression — the exporter no longer parses — and
+costs nearly nothing. Not every check needs to be deep; it needs to be
+*proportionate*. (Deliberately absent: installing PyTorch here — the
+e2e job already exercises the exporter for real.)
+
+---
+
+## Part 4 — `nightly.yml`: what's too slow for every diff
+
+Two checks are worth running but too slow (or too statistical) to make
+every contributor wait for. They run on a schedule —
+`cron: "17 7 * * *"`, which is cron notation for "07:17 UTC daily" —
+plus `workflow_dispatch`, meaning you can click "run now."
+
+**`tsan`** rebuilds everything under **ThreadSanitizer**, which watches
+the ordering of every memory access across threads and reports *data
+races* — two threads touching the same location, at least one writing,
+with no synchronization between them. Races are the ultimate
+"works on my machine" bug: their outcome depends on scheduling luck.
+SeeML's test tree already contains genuine race *scenarios* run in
+anger — two engines training concurrently on the shared worker pool,
+two writers racing one durable file, a batch pipeline torn down
+mid-stream — and TSan runs *underneath* those tests, converting "the
+assertions held this time" into "no race existed on any interleaving
+TSan observed." That's the boundedness promise, proven rather than
+sampled. At ~10× slowdown, it's a nightly.
+
+**`fuzz-extended`** is the same fuzzer as 3.4 with a budget of fifteen
+minutes — and one crucial upgrade: the **corpus** (the set of
+interesting inputs discovered so far) is cached between runs via
+`actions/cache`. Tonight's fuzzing starts where last night's stopped.
+Coverage compounds. This is the difference between poking at a lock for
+90 seconds and hiring someone to pick it a little further every night.
+
+A nightly failure has no pull request attached — it means **main
+itself** regressed (or a latent bug finally surfaced). Treat it with
+red-PR severity; the only thing worse than a broken main is a broken
+main nobody is looking at.
+
+---
+
+## Part 5 — `codeql.yml`: checking the paths nothing executes
+
+Everything above is **dynamic** analysis: run the code, observe it.
+Dynamic analysis has one blind spot by construction — it only sees the
+paths that actually execute. The error path with the off-by-one, the
+integer conversion in a branch no fixture reaches: invisible.
+
+**CodeQL** is the complement: **static** analysis. It compiles the code
+(tracing the same `build/build.sh` as everything else, so the analyzed
+tree is exactly the shipped tree), builds a database of every function,
+call, and dataflow edge, and runs queries against it — "does any
+attacker-influenced length reach an allocation without a bounds
+check?", "is any signed value narrowed where it could wrap?" — across
+*all* paths, executed or not. Findings appear in the repository's
+Security tab with the dataflow spelled out step by step.
+
+It runs per pull request, per push to main, and — because query suites
+themselves improve over time — on a weekly schedule, so the *same* code
+gets re-examined by *smarter* queries as they ship.
+
+Neither static nor dynamic analysis subsumes the other: sanitizers
+prove facts about real executions; CodeQL reasons about hypothetical
+ones. You want both, which is why both exist here.
+
+---
+
+## Part 6 — Reading a red build
+
+The practical skill. A check failed on your PR — now what?
+
+1. **The job name is the diagnosis.** `determinism` red? You introduced
+   a scheduling-dependent numeric. `asan-ubsan` red but `build-and-test`
+   green? Memory or UB bug that happens not to crash. `e2e-package` red
+   alone? You broke the emitted package or the CLI seam, not the
+   library. Only gcc red? You wrote clang-flavored C++.
+2. **Reproduce locally with the same knob.** Every job is a wrapper
+   around commands you can run yourself: `SEEML_THREADS=3
+   ./build/seeml_kernels_test`, or the sanitizer build via
+   `cmake -DSEEML_SANITIZE="address;undefined"`. The workflows
+   deliberately contain no logic that exists only in CI.
+3. **Artifacts are your counterexample.** A fuzz failure uploads the
+   crashing file; feed it back to the harness locally and you have a
+   deterministic reproducer.
+4. **Never retry your way to green.** Every check here is seeded and
+   deterministic *by design* (that's promise #2 doing double duty: it
+   makes CI itself non-flaky). If a rerun changes the verdict, that
+   contradiction is itself a determinism bug — file it as one.
+
+---
+
+## Part 7 — Takeaways
+
+- A workflow is just a program that runs your checks on every change,
+  because humans forget and machines don't.
+- Structure follows promises: **one job per invariant**, so a red check
+  names what broke before you read a single log line.
+- Exit codes are propositions. Design every step so its exit code
+  *means* something, and never let a check that couldn't run
+  impersonate a check that passed.
+- Sample the awkward points: odd thread widths, hostile bytes, missing
+  devices, both compilers.
+- Split by cost: cheap and deterministic gates every diff; slow and
+  statistical runs nightly; static analysis covers what dynamic
+  execution can't reach.
+- Determinism isn't only a product feature — it's what makes the CI
+  itself trustworthy. Flaky checks train people to ignore red, and an
+  ignored red is worse than no check at all.
+
+Where to go next: the invariants themselves are specified in
+[compiler.md](compiler.md) and [runtime.md](runtime.md); the test tree
+these workflows execute is mapped in [test/README.md](../test/README.md);
+the binary formats the fuzzer attacks are in [formats.md](formats.md).
+
+*This was workflows.*


### PR DESCRIPTION
# CI: continuously assert the project's invariants on every diff

Replaces the deleted `.github/workflows`. Two workflows, mapped directly onto the three invariant classes the codebase is built around. Stacked on #45 (→ #44).

## `ci.yml` — gates every PR and push to main

| job | invariant | what it proves |
|---|---|---|
| **build-and-test** (Linux gcc / Linux clang / macOS clang) | correctness | the canonical `build/build.sh` + all 25 suites on every supported toolchain; macOS also compiles the ObjC++ Metal harness (suite self-degrades without a device) |
| **determinism** (`SEEML_THREADS` ∈ {1, 3, 8}) | determinism | every in-test bitwise assertion — plan bytes, persist segments, kernel outputs, hashes — executes under serial, odd, and wide pool shapes; any scheduling-dependent numeric trips at least one width |
| **asan-ubsan** | correctness | full suites under Address+UB sanitizers via the existing `-DSEEML_SANITIZE` plumbing — the `int8(clamp(NaN))` bug class becomes a red build |
| **fuzz-smoke** (90 s) | correctness | bounded pass over the four untrusted-input arms (SMF, SEEU, SDS, compile-of-loader-accepted-SMF); crashes uploaded as artifacts |
| **exporter-syntax** | correctness | `export_model.py` byte-compiles (torch-free — its torch imports are function-local by design) |

## `nightly.yml` — daily on main + `workflow_dispatch`

| job | invariant | what it proves |
|---|---|---|
| **tsan** | bounded concurrency | the whole suite set under ThreadSanitizer — the race detector runs *underneath* the concurrency integration tests from #45 (racing durable writers, concurrent engines on the shared pool, pipeline teardown, chunk-exception path) |
| **fuzz-extended** (15 min, cached corpus) | correctness | the long campaign the PR smoke can't afford; corpus persists via the actions cache so coverage compounds nightly |

## Design notes
- The suites carry the assertions; CI's job is running them where a dev machine doesn't (other toolchains, sanitizers, varied widths) and refusing the merge otherwise.
- `concurrency.cancel-in-progress` keeps superseded pushes from queuing; every job has a hard timeout.
- Statistical tests (adapter-init bounds) are seeded and deterministic, so they gate PRs without flake risk; the genuinely nondeterministic checks (races under TSan, fuzz) are bounded by design.
- Verified locally: YAML parses, suite glob matches all 25 binaries, the width loop and `py_compile` gate run. The Linux/CMake/sanitizer cells get their first live verification on this PR's own CI run — if a cell needs a toolchain tweak (e.g., a gcc-only warning under `-Werror`), that run will say so precisely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
