### PR TITLE
docs: per-subsystem README.md for compiler / runtime / source / tool

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,118 @@
+# Building SeeML
+
+## What does it even mean to "build" a program?
+
+You've written source code — text files ending in `.cc` and `.h`. A computer
+can't run text; it runs machine code. **Building** is the process of turning
+one into the other, and it happens in two distinct steps that are worth
+keeping separate in your head:
+
+1. **Compile.** The compiler (`clang++` or `g++`) reads *one* `.cc` file at a
+   time and translates it into an **object file** (`.o`) — machine code, but
+   *incomplete*: it still has holes where it calls functions defined in other
+   files. Sixty source files means sixty object files, each compiled on its
+   own, in ignorance of the others.
+2. **Link.** The linker takes all those object files and stitches them
+   together — filling every hole with the address of the function it needs —
+   into a single runnable **executable**.
+
+So the whole story is: *many `.cc` → many `.o` (compile) → one program
+(link).* Every build system, no matter how fancy, is just automating those
+two steps.
+
+## Why not just type the compiler commands yourself?
+
+You could. For one file, `clang++ hello.cc -o hello` is the whole build. But
+SeeML has ~90 source files and two dozen test programs. Typing ninety compile
+commands and then a link command by hand, every time you change one line,
+would be miserable and error-prone. Worse, if you change *one* file, you'd
+want to recompile only *that* file and re-link — not redo all ninety.
+
+A **build system** is a program that knows the list of files, the commands,
+and (sometimes) which outputs are stale, so `build` becomes one word instead
+of ninety commands. SeeML gives you two, and they produce the identical
+result.
+
+## What's actually in this folder
+
+Almost nothing here is source code. This directory is mostly the *output* of
+a build — the `.o` object files and the `seeml_*` executables land here — and
+all of that is git-ignored, because it's regenerated, never edited. **The one
+file you'd ever open is `build.sh`.** (The other build system, CMake, is
+driven by `CMakeLists.txt` up in the repository root.)
+
+```
+build/
+  build.sh              the CMake-free build (the only tracked file here)
+  *.o                   compiled object files      ── generated, git-ignored
+  seeml-update-compile  the compiler CLI           ── generated
+  seeml-seeu-dump       the plan disassembler      ── generated
+  seeml_*_test          one executable per suite   ── generated
+```
+
+## The two ways to build
+
+**Option A — `build.sh` (no tools required).** A plain shell script. It needs
+nothing but a C++ compiler — no build tool installed at all. Read it top to
+bottom and you see *every* command it runs: it compiles each `.cc` into a
+`.o`, groups the object files into the three libraries the project is made of,
+then links the tools and every test suite. It is deliberately transparent —
+when a build breaks on some unfamiliar machine, the entire build is one file
+you can read.
+
+```bash
+sh build/build.sh
+```
+
+**Option B — CMake (the industry standard).** CMake reads `CMakeLists.txt`,
+figures out the compile/link commands for *your* platform and compiler, and
+writes them out for a tool like `make` or `ninja` to run. It does the things a
+hand-written script won't: rebuild only what changed, integrate with IDEs and
+debuggers, run the test suite through `ctest`, and switch on the sanitizer and
+fuzzing builds used in CI.
+
+```bash
+cmake -S . -B build-cmake      # -S = source dir, -B = where to put the build
+cmake --build build-cmake -j   # -j = compile files in parallel
+ctest --test-dir build-cmake   # run every test suite
+```
+
+(Note the CMake build goes in a *separate* `build-cmake/` directory. Keeping
+generated files out of your source tree — an "out-of-source build" — is a
+convention worth adopting: you can delete the whole thing to start clean, and
+never accidentally commit a build artifact.)
+
+## Reading a compile command
+
+Every compile in `build.sh` uses the same flags. They're worth knowing:
+
+| flag | what it does |
+|---|---|
+| `-std=c++23` | use the 2023 C++ standard (the codebase relies on `std::expected`) |
+| `-I.` | look for `#include "..."` files starting at the repository root |
+| `-O2` | optimize the machine code (level 2 — a good speed/compile-time balance) |
+| `-Wall -Wextra` | turn on warnings — the compiler telling you about likely mistakes |
+| `-Werror` | treat every warning as a hard error, so none can be ignored |
+| `-pthread` | enable threads (the runtime parallelizes its kernels) |
+| `-c` | *compile only* — stop after making the `.o`, don't link yet |
+| `-o NAME` | name the output file |
+
+## After it builds
+
+Every test suite is its own executable; run one directly:
+
+```bash
+./build/seeml_updater_test
+```
+
+The two tools are here too — `./build/seeml-update-compile` and
+`./build/seeml-seeu-dump`.
+
+## Where to go next
+
+This is *building the compiler*. A different, later build appears once the
+compiler runs: the update package it emits contains *its own* generated
+`build.sh` that compiles the vendored runtime on the device — that flow, and
+every command-line flag, is in **[docs/usage.md](../docs/usage.md)**. The two
+build systems here mirror each other file-for-file; the test tree they compile
+is mapped in [test/README.md](../test/README.md).

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -1,0 +1,72 @@
+# The SeeML Compiler
+
+## What does it mean to *compile* training?
+
+Ordinarily, training a model is something you *run* — a framework interprets
+your graph, allocates memory as it goes, and dispatches kernels on the fly.
+SeeML's compiler moves all of that to the build host and decides it *once*:
+it takes a frozen model plus a configuration ("adapt this with rank-8 LoRA,
+cross-entropy, AdamW, 1,000 steps") and emits a `.seeu` **update plan** —
+three flat instruction streams and every byte of memory layout the device
+will ever need. Everything a compiler settles ahead of time is something
+that *cannot go wrong on the device*.
+
+The tree is partitioned into five subsystems, each named for its role in
+the compilation, and each subsystem into folders named for the discipline
+of the work inside. Where a folder splits across files, a single façade
+header is the only include consumers need.
+
+```
+compiler/
+  frontend/               SMF bytes -> verified forward SIR
+    ingressor/            bounds-checked file load, footprint gate
+    parser/               op list -> SIR, with semantic analysis
+    operator/             typed constructors for compound ops
+    representation/       SIR itself (façade: sir.h)
+  analysis/               forward SIR -> complete training program
+    updater/              pass manager, conv lowering, dead-code elimination
+    algebra/              LoRA grafting, merge program, GEMM-epilogue fusion
+    calculus/             autodiff and optimizer synthesis
+    reviewer/             int8 quantization selection
+  backend/                training program -> .seeu plan + native package
+    trainer/              arena binding, instruction lowering, package emit
+    architecture/         host cache/ISA detection, GEMM tiling
+    tuner/                UCB1 bandit tiling autotuner
+  driver/                 orchestrates the process, verifies every boundary
+  diagnostics/            errors, partitioned by process
+    tokenizing/ parsing/ passing/ updating/ architecting/ generating/
+```
+
+## The shape of the pipeline
+
+Read the folders top to bottom and you have the pipeline. **`frontend/`**
+turns untrusted SMF (SeeML Model Format) bytes into SIR — the SSA
+intermediate representation every later stage agrees on — refusing
+malformed files and models that provably can't fit in memory.
+**`analysis/`** is where the training program is *built*: LoRA adapters are
+grafted onto the frozen weights, the backward pass and optimizer are
+synthesized as more SIR (a program differentiating a program), and the
+merge program is written. **`backend/`** is code generation: it lays out
+one arena with no lifetime collisions, lowers SIR to the fixed 64-byte
+instruction stream, and packages the result. **`driver/`** owns the
+*process* — it sequences the stages and, at every seam, re-proves that each
+subsystem produced what the next one assumes. **`diagnostics/`** gives every
+error a single-line, unit-attributed home.
+
+Two things worth internalizing: SIR ops carry dialect prefixes (`sc_mem.*`
+storage, `sc_high.*` differentiable forward, `sc_low.*` synthesized
+adjoints/steps) so you always know which layer of the story you're in; and
+`driver/contract.h` is where the compiler distrusts *itself*, catching a
+misused subsystem as a compiler bug rather than letting it reach the device.
+
+## Where to go next
+
+This is the orientation; the teaching is in
+**[docs/compiler.md](../docs/compiler.md)**, which walks every stage from
+first principles — what an IR is, the linear algebra of LoRA, how autodiff
+works, memory planning as register allocation, cache-aware tiling, and the
+bandit that tunes it. The binary formats it reads and writes are in
+[docs/formats.md](../docs/formats.md); the runtime that executes its output
+is in [docs/runtime.md](../docs/runtime.md). The suites that verify each
+subsystem live under [test/compiler/](../test/README.md), one folder per
+subsystem here.

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,0 +1,69 @@
+# The SeeML Runtime
+
+## A virtual machine whose instruction set is *training*
+
+A CPU fetches an instruction, decodes it, executes it, repeats — and nothing
+says the machine doing that must be hardware. SeeML's runtime is a virtual
+machine whose opcodes happen to be forward passes, gradients, and optimizer
+steps. It is the **zero-dependency** half of the product: the code vendored
+into every emitted package and run on the device. No framework, no allocator
+churn, no graph library — because the [compiler](../compiler/README.md)
+already decided everything. What's left on the device is deliberately
+boring: one allocation, one thread pool, three fixed instruction streams,
+and a dispatch loop.
+
+But "boring" is *earned*. The runtime's real job, beyond executing, is
+refusing to execute anything it cannot first prove safe. It is partitioned
+in the same fashion as the compiler — subsystems by role, folders by
+discipline, façade headers where units split — with `engine/` playing the
+driver's role.
+
+```
+runtime/
+  engine/                 orchestrates the update, verifies every boundary
+    update_engine         load -> train -> gate -> merge -> commit
+    contract              the load-time boundary proofs
+  feeder/                 corpus decode and pipelined batch staging
+    dataset               SDS load, shuffle/split, token records
+    batch_pipeline        stage the next batch while this step computes
+  executor/               the kernel library the dispatcher runs
+    update_kernels.h      façade over the families below
+    kernel_policy.h       the determinism + aliasing contract
+    gemm elementwise activation normalization loss optimizer attention
+    metal_gemm            (Apple-only) GPU GEMM dispatch harness
+  validator/              load-time bounds proof of every instruction
+  custodian/              durable state — checkpoints, atomic commits
+  diagnostics/            errors, partitioned by process
+    feeding/ validating/ executing/ persisting/
+```
+
+## The update, phase by phase
+
+Read `engine/` as the spine. **Load** checks the plan's identity and
+integrity, then re-proves — through **`validator/`** — that every operand of
+every instruction is in bounds, so the hot loop can later dispatch *blindly*.
+**Train** pulls batches from **`feeder/`** (which stages batch *s+1* while
+step *s* runs) and executes the train stream through **`executor/`**. **Gate**
+runs the eval program before and after; no improvement means the device is
+left untouched. **Merge** materializes each adapter's delta, and **Commit**
+adds those deltas onto the source file's pristine weights and writes the
+result through **`custodian/`** — fsync then atomic rename, so a power cut
+leaves the old file or the new one, never a torn one.
+
+Two properties hold across all of it, and both are contracts the tests pin:
+execution is **bitwise-deterministic** at any thread count (the executor
+chunks work by problem shape, never by worker count), and every data-
+dependent index — a class label, a token id — is proven inside its bound at
+load, so a validated program can gather and index without a single runtime
+check.
+
+## Where to go next
+
+This is the map; the walkthrough is in
+**[docs/runtime.md](../docs/runtime.md)** — load-time validation as a safety
+proof, why naive kernel formulas explode and how these stay numerically
+stable, the deterministic parallelism, the producer-consumer pipeline, and
+storage that survives a power cut. The plan format it consumes is in
+[docs/formats.md](../docs/formats.md); the compiler that produces it is in
+[docs/compiler.md](../docs/compiler.md). Every subsystem here has a matching
+suite under [test/runtime/](../test/README.md).

--- a/source/README.md
+++ b/source/README.md
@@ -1,0 +1,58 @@
+# The SeeML Source Language & Substrate
+
+## Why isn't this under `compiler/`?
+
+Because it isn't a stage of compilation. `source/` holds the abstractions of
+the *source language itself* — the model container, the plan ABI — and the
+low-level substrate both halves of the product share. The
+[compiler](../compiler/README.md) consumes these; the
+[runtime](../runtime/README.md) consumes these; neither *owns* them. Putting
+them here, outside both, is what lets the two halves agree on every byte
+without depending on each other.
+
+```
+source/
+  language/               the SMF model container (SeeML Model Format)
+    model_format          the parsed structs + on-disk layout constants
+  plan/                   the compiler <-> runtime ABI (façade: update_types.h)
+    config                the compilation request (UpdateConfig)
+    instruction           the 64-byte instruction word + opcode vocabulary
+    schema                the .seeu container header + emit table
+  parallel/               deterministic chunked data-parallelism
+    parallel_for          the leaked worker pool, chunk geometry by shape
+  identity/               content hashing for integrity
+    hash                  ContentHash64 + the in-blob PlanSelfHash seal
+```
+
+## The four things everyone shares
+
+**`language/`** defines what a model *is* on disk — tensors, ops, the
+byte layout — so the exporter, the compiler's loader, and the tools all
+speak one format. **`plan/`** is the crucial seam: it is the entire
+vocabulary the compiler and runtime share — the instruction set the compiler
+*writes* and the runtime *reads*, plus the container header addressing every
+section. Change it in one place and both halves move together.
+
+**`parallel/`** and **`identity/`** are the substrate that makes the
+product's headline promises possible. `parallel_for` chunks work by problem
+shape and never by thread count — the single reason results are
+**bitwise-identical** whether one core ran or eight. `hash` is the
+integrity layer: a parallel FNV-1a variant that fingerprints a model (so
+commit refuses the wrong file) and seals a plan (so a flipped bit is caught
+at load, not as silent garbage on-device).
+
+The discipline to notice: `plan/` is an *ABI*, so its structs are
+`#pragma pack(1)` with `static_assert`s on their sizes — a layout change is
+a versioned event, negotiated by the runtime's version policy, never an
+accident.
+
+## Where to go next
+
+The byte-level formats — every field, offset, and magic number, and *why*
+each is there — are specified in **[docs/formats.md](../docs/formats.md)**.
+The parallelism and hashing machinery is taught where it matters most, in
+[docs/runtime.md](../docs/runtime.md). How the compiler consumes all of this
+is in [docs/compiler.md](../docs/compiler.md). The substrate's own suites
+live under [test/source/](../test/README.md) (`parallel_for`, `hash`); the
+`language/` and `plan/` structs are exercised throughout the compiler and
+runtime suites.

--- a/tool/README.md
+++ b/tool/README.md
@@ -1,0 +1,45 @@
+# The SeeML Tools
+
+## The human-facing edge of the pipeline
+
+Everything else in the repository is a library. `tool/` is where a person
+actually stands: it's how a model *gets into* SeeML, how the update plan is
+*produced*, and how you *look inside* one when something seems wrong. Three
+programs, each a thin, strict shell around the libraries the rest of the
+tree provides.
+
+```
+tool/
+  export_model.py         PyTorch model + data  ->  SMF / SDS files
+  seeml_update_compile.cc the compiler CLI       ->  a .seeu update package
+  seeml_seeu_dump.cc      the plan disassembler   (inspect any .seeu)
+```
+
+## What each one is for
+
+**`export_model.py`** is the on-ramp: it converts a PyTorch `nn.Sequential`
+(or a decoder stack) into the SMF model container and turns arrays into an
+SDS corpus — the only Python in the product, and the only place PyTorch is
+needed. Everything downstream is dependency-free C++.
+
+**`seeml_update_compile.cc`** is the compiler itself as a command: source
+model in, `.seeu` plan (and optional self-contained native package) out. Its
+argument parsing is deliberately *strict* — an unknown flag, a flag missing
+its value, or a numeric with trailing garbage is a hard error, never a
+silent default — because a fine-tune you didn't mean to configure is worse
+than one that refuses to start.
+
+**`seeml_seeu_dump.cc`** is the disassembler: point it at any plan and it
+verifies the integrity seal and prints the header and instruction streams in
+human-readable form — the tool you reach for when a plan misbehaves and you
+need to see what the compiler actually emitted.
+
+## Where to go next
+
+The full workflow — export, compile, run on-device — with **every flag
+explained and every exit code**, is in
+**[docs/usage.md](../docs/usage.md)**; start there. What the compile step
+does internally is in [docs/compiler.md](../docs/compiler.md); the formats
+these tools read and write are in [docs/formats.md](../docs/formats.md). The
+compile CLI's argument discipline is verified alongside the driver suites
+under [test/compiler/driver/](../test/README.md).


### PR DESCRIPTION
Adds a `README.md` to each code subsystem — `compiler/`, `runtime/`, `source/`, `tool/` — in the exact style of the existing `test/README.md`: a first-principles framing question, an annotated folder tree, the basic shape of what the subsystem does, and pointers into `docs/` for the full teaching. Nothing here duplicates the architecture docs; each README orients a reader who lands in the directory, then hands off.

- **compiler/README.md** — the five subsystems read top-to-bottom as the pipeline (frontend → analysis → backend → driver → diagnostics); SIR dialects; the driver contracts that make the compiler distrust itself. → docs/compiler.md
- **runtime/README.md** — the virtual machine whose opcodes are training; the load → train → gate → merge → commit spine; the determinism and proven-index contracts. → docs/runtime.md
- **source/README.md** — why the shared substrate sits outside both halves; the language/plan ABI, deterministic `parallel_for`, and integrity hashing. → docs/formats.md
- **tool/README.md** — the human-facing edge (export / compile / dump) and the strict-CLI discipline. → docs/usage.md

All relative doc/test links verified against the tree. Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
