### PR TITLE
Add MIT license, single-source the release version, declare Python deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required(VERSION 3.20)
-project(seeml VERSION 1.2.0 LANGUAGES CXX)
+
+# The release version has one home: source/identity/version.h. Extract it at
+# configure time so CMake, the tools, and build.sh can never disagree.
+file(STRINGS source/identity/version.h _seeml_version_line REGEX "kSeemlVersion")
+string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" SEEML_VERSION "${_seeml_version_line}")
+if(NOT SEEML_VERSION)
+    message(FATAL_ERROR "cannot parse kSeemlVersion from source/identity/version.h")
+endif()
+project(seeml VERSION ${SEEML_VERSION} LANGUAGES CXX)
 
 # ==============================================================================
 # Global Configuration

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Shuo Zheng
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ It turns out the answer is a compiler.
 
 - **Build and run:** a C++23 compiler (clang or gcc). CMake is supported but
   optional — `build/build.sh` drives a full build with `sh` alone.
-- **Model export only:** Python 3 with PyTorch (`tool/export_model.py`).
+- **Model export only:** Python 3 with PyTorch and NumPy
+  (`tool/export_model.py`); `pip install -r tool/requirements.txt` installs
+  both.
 - **On-device:** nothing. The runtime is zero-dependency and vendored into
   every emitted package; the package builds with no access to this
   repository.
@@ -101,5 +103,9 @@ What SeeML can train today, stated up front:
 - **Integrity, not authenticity.** All hashing is FNV-1a — a corruption and
   mismatch detector, not a signature. Authenticate plans in your update
   transport.
+
+## License
+
+MIT — see [LICENSE](LICENSE).
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,6 +16,8 @@ Notice what does *not* travel to the device: PyTorch, Python, this repository. T
 
 ## Step 1: Export the Model (build host, PyTorch)
 
+The exporter needs Python 3 with PyTorch and NumPy on the build host — `pip install -r tool/requirements.txt` installs both. Nothing on the device side touches Python.
+
 The quickest start — a demo model, teacher, and synthetic corpus in one command:
 
 ```bash

--- a/source/identity/version.h
+++ b/source/identity/version.h
@@ -1,0 +1,20 @@
+#ifndef SEEML_SOURCE_IDENTITY_VERSION_H_
+#define SEEML_SOURCE_IDENTITY_VERSION_H_
+
+// =============================================================================
+// The release version, in exactly one place.
+//
+// Everything that reports a version derives it from this constant: CMake
+// extracts it for project(VERSION ...) at configure time, and both CLI
+// tools print it for --version. The wire-format versions (SMF, SDS, SEEU,
+// checkpoint) are deliberately separate — they gate compatibility and move
+// only when a format changes; this constant names the release.
+// =============================================================================
+
+namespace seeml::update {
+
+inline constexpr char kSeemlVersion[] = "1.2.0";
+
+}  // namespace seeml::update
+
+#endif  // SEEML_SOURCE_IDENTITY_VERSION_H_

--- a/tool/README.md
+++ b/tool/README.md
@@ -19,8 +19,9 @@ tool/
 
 **`export_model.py`** is the on-ramp: it converts a PyTorch `nn.Sequential`
 (or a decoder stack) into the SMF model container and turns arrays into an
-SDS corpus — the only Python in the product, and the only place PyTorch is
-needed. Everything downstream is dependency-free C++.
+SDS corpus — the only Python in the product, and the only place PyTorch and
+NumPy are needed (`pip install -r tool/requirements.txt`). Everything
+downstream is dependency-free C++.
 
 **`seeml_update_compile.cc`** is the compiler itself as a command: source
 model in, `.seeu` plan (and optional self-contained native package) out. Its

--- a/tool/requirements.txt
+++ b/tool/requirements.txt
@@ -1,0 +1,4 @@
+# Build-host dependencies for tool/export_model.py — model export only.
+# The compiler, the runtime, and every emitted package need none of this.
+torch>=1.7    # nn.SiLU is the newest module the exporter touches
+numpy>=1.17   # np.random.Generator API used by --demo

--- a/tool/seeml_seeu_dump.cc
+++ b/tool/seeml_seeu_dump.cc
@@ -1,12 +1,13 @@
 // =============================================================================
 // seeml-seeu-dump — .seeu Update Plan disassembler.
 //
-//   seeml-seeu-dump plan.seeu [--instrs]
+//   seeml-seeu-dump plan.seeu [--instrs] [--version]
 //
 // Prints the plan header (memory contract, I/O slots, hyperparameters,
 // integrity hashes, section table) and, with --instrs, disassembles the
 // train / eval / merge instruction streams. This is the field-debugging
-// tool: it depends only on update_types.h + hash.h so it builds anywhere.
+// tool: it depends only on update_types.h + hash.h + version.h so it
+// builds anywhere.
 // =============================================================================
 
 #include <cinttypes>
@@ -17,6 +18,7 @@
 
 #include "source/plan/update_types.h"
 #include "source/identity/hash.h"
+#include "source/identity/version.h"
 
 namespace {
 
@@ -222,6 +224,15 @@ bool SectionInBounds(uint64_t offset, uint64_t count, uint64_t elem_bytes,
 }  // namespace
 
 int main(int argc, char** argv) {
+  if (argc >= 2 && (std::strcmp(argv[1], "--help") == 0 ||
+                    std::strcmp(argv[1], "-h") == 0)) {
+    std::printf("usage: seeml-seeu-dump plan.seeu [--instrs] [--version]\n");
+    return 0;
+  }
+  if (argc >= 2 && std::strcmp(argv[1], "--version") == 0) {
+    std::printf("seeml-seeu-dump %s\n", kSeemlVersion);
+    return 0;
+  }
   if (argc < 2) {
     std::fprintf(stderr, "usage: seeml-seeu-dump plan.seeu [--instrs]\n");
     return 2;

--- a/tool/seeml_update_compile.cc
+++ b/tool/seeml_update_compile.cc
@@ -20,6 +20,7 @@
 //       [--steps 1000]                 default step count baked into the plan
 //       [--report report.json]         machine-readable compile report
 //       [--build]                      run build.sh after emission
+//       [--version]                    print the release version
 //
 // Every numeric flag is parsed strictly: trailing garbage, overflow, or an
 // unknown flag is a hard error, never a silent default.
@@ -42,6 +43,7 @@
 #include "compiler/backend/trainer/native_emitter.h"
 #include "compiler/driver/update_compiler.h"
 #include "compiler/frontend/ingressor/model_reader.h"
+#include "source/identity/version.h"
 
 namespace {
 
@@ -62,7 +64,8 @@ void PrintUsage() {
                "  [--weight-decay WD] [--clip-norm C]\n"
                "  [--lr-schedule const|cosine] [--warmup N]\n"
                "  [--min-lr-factor F] [--quantize-base] [--steps N]\n"
-               "  [--no-fuse-epilogue] [--report out.json] [--build]\n");
+               "  [--no-fuse-epilogue] [--report out.json] [--build]\n"
+               "  [--version]\n");
 }
 
 /// Strict argument cursor: every flag must be known, every value must parse
@@ -193,6 +196,11 @@ int main(int argc, char** argv) {
 
   if (args.Take("--help") || args.Take("-h")) {
     PrintUsage();
+    return 0;
+  }
+
+  if (args.Take("--version")) {
+    std::printf("seeml-update-compile %s\n", kSeemlVersion);
     return 0;
   }
 


### PR DESCRIPTION
- LICENSE (MIT) at the root; README gains a License section.
- source/identity/version.h owns kSeemlVersion; CMake extracts it for project(VERSION ...) so the header, CMake, and build.sh cannot disagree.
- Both CLI tools gain --version; seeml-seeu-dump also gains --help/-h, which it previously treated as a file name.
- tool/requirements.txt declares torch>=1.7 and numpy>=1.17; NumPy was a hard dependency of export_model.py but was documented nowhere.