### PR TITLE
Fix the four friction items from the v1.0.2 client-experience run

### DIFF
--- a/compiler/backend/trainer/native_emitter.cc
+++ b/compiler/backend/trainer/native_emitter.cc
@@ -172,6 +172,14 @@ int main(int argc, char** argv) {
     std::fprintf(stderr, "load: %s\n", r.error().c_str());
     return 1;
   }
+
+  // Fail fast: the plan's emit offsets are only meaningful inside the exact
+  // file it was compiled from, and commit would refuse anyway — but only
+  // after the full training run. One file scan here buys that refusal now.
+  if (auto r = engine.VerifySourceModel(model); !r) {
+    std::fprintf(stderr, "model: %s\n", r.error().c_str());
+    return 1;
+  }
   std::fprintf(stderr,
                "seeml-update: resource contract — arena %llu bytes"
                " (%llu persistent)\n",
@@ -327,6 +335,8 @@ std::string BuildScript(const GemmTiling* tiling) {
        "activation.o normalization.o loss.o optimizer.o attention.o "
        "parallel_for.o durable_io.o plan_validator.o checkpoint.o "
        "-o model_update\n";
+  s += "# The .o files are intermediates; the deliverable is the binary.\n";
+  s += "rm -f ./*.o\n";
   s += "echo \"built: $(pwd)/model_update\"\n";
   return s;
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -103,7 +103,7 @@ What happens, in order:
 4. **Gate** — validation loss is evaluated before and after training with the plan's eval program. No improvement → exit code 3 and the device is left *untouched* (`--force` overrides, if you must).
 5. **Merge + commit** — deltas `Δ = (α/r)·A@B` are materialized and added to the pristine f32 weights of the source file (which must hash-match the plan), written durably, renamed atomically. A power cut at any moment leaves the old model or the new one — never a torn file.
 
-Exit codes are the API for your update orchestrator: `0` committed, `1` runtime error, `2` bad arguments, `3` regression-gate rejection. `--loss-log` appends a CSV loss curve if you want to watch the descent.
+Exit codes are the API for your update orchestrator: `0` committed, `1` runtime error, `2` bad arguments, `3` regression-gate rejection. `--loss-log` writes the full per-step CSV loss curve once training completes (it is not appended live, so tail it after the run, not during).
 
 ## Threading and Determinism
 

--- a/runtime/engine/update_engine.cc
+++ b/runtime/engine/update_engine.cc
@@ -739,6 +739,19 @@ std::expected<void, std::string> UpdateEngine::RunMerge() {
   return {};
 }
 
+std::expected<void, std::string> UpdateEngine::VerifySourceModel(
+    const std::string& source_model_path) const {
+  if (header_.source_model_hash == 0) return {};
+  auto hash = HashFileContent(source_model_path);
+  if (!hash) return std::unexpected(hash.error());
+  if (*hash != header_.source_model_hash)
+    return diag::executing::Error(
+        "source model does not match the plan's "
+        "source_model_hash — refusing to run against '" +
+        source_model_path + "'");
+  return {};
+}
+
 std::expected<void, std::string> UpdateEngine::CommitToModel(
     const std::string& source_model_path, const std::string& out_path) const {
   if (!merged_)

--- a/runtime/engine/update_engine.h
+++ b/runtime/engine/update_engine.h
@@ -140,6 +140,14 @@ class UpdateEngine {
   [[nodiscard]] std::expected<void, std::string> CommitToModel(
       const std::string& source_model_path, const std::string& out_path) const;
 
+  /// Checks that `source_model_path` hashes to the plan's source_model_hash,
+  /// without training or writing anything. CommitToModel re-verifies the
+  /// copy it patches (no TOCTOU window); calling this right after load
+  /// merely fails fast — a mismatched model costs one file scan instead of
+  /// a full training run. Plans with no hash binding (hash 0) always pass.
+  [[nodiscard]] std::expected<void, std::string> VerifySourceModel(
+      const std::string& source_model_path) const;
+
   [[nodiscard]] std::expected<void, std::string> SaveCheckpoint(
       const std::string& path) const;
   [[nodiscard]] std::expected<void, std::string> LoadCheckpoint(

--- a/source/identity/version.h
+++ b/source/identity/version.h
@@ -13,7 +13,7 @@
 
 namespace seeml::update {
 
-inline constexpr char kSeemlVersion[] = "1.2.0";
+inline constexpr char kSeemlVersion[] = "1.0.2";
 
 }  // namespace seeml::update
 

--- a/test/runtime/engine/update_engine_test.cc
+++ b/test/runtime/engine/update_engine_test.cc
@@ -513,6 +513,28 @@ TEST(UpdateEngineCommit, RejectsModelFileThePlanWasNotCompiledFrom) {
   EXPECT_OK(engine.CommitToModel(right, dir.File("ok.smf")));
 }
 
+TEST(UpdateEngineCommit, VerifySourceModelFailsFastOnTheWrongFile) {
+  ScopedTempDir dir;
+  SmfModel model = MakeMlp(kInDim, 10, 3, 1);
+  SmfModel other = MakeMlp(kInDim, 10, 3, 99);  // same shapes, other bytes
+  const std::string right = dir.File("right.smf");
+  const std::string wrong = dir.File("wrong.smf");
+  ASSERT_OK(SaveSmf(right, model));
+  ASSERT_OK(SaveSmf(wrong, other));
+
+  ASSERT_OK_AND_ASSIGN(SmfModel saved, LoadSmf(right));
+  auto compiled = UpdateCompiler(BaseConfig(kBatch)).Compile(saved);
+  ASSERT_OK(compiled);
+  UpdateEngine engine;
+  ASSERT_OK(engine.LoadFromMemory(compiled->plan.data(),
+                                  compiled->plan.size()));
+
+  // No train, no merge: the pre-flight check must work straight after load —
+  // its whole purpose is refusing before any training cycles are spent.
+  EXPECT_ERROR_CONTAINS(engine.VerifySourceModel(wrong), "source_model_hash");
+  EXPECT_OK(engine.VerifySourceModel(right));
+}
+
 TEST(UpdateEngineCommit, EvaluateBetweenMergeAndCommitDoesNotCorruptDeltas) {
   // Train -> RunMerge -> Evaluate -> CommitToModel is the natural
   // "validate after merging" sequence. The merge's delta buffers must live

--- a/tool/seeml_seeu_dump.cc
+++ b/tool/seeml_seeu_dump.cc
@@ -299,11 +299,12 @@ int main(int argc, char** argv) {
   // Verify the integrity seal the same way the runtime does.
   const uint64_t state = PlanSelfHash(plan.data(), plan.size(),
                                       offsetof(PlanHeader, plan_hash));
+  const bool sealed = state == h.plan_hash;
 
   std::printf("seeu plan: %s\n", argv[1]);
   std::printf("  version            %u\n", h.version);
   std::printf("  plan_hash          %016" PRIx64 "  (%s)\n", h.plan_hash,
-              state == h.plan_hash ? "verified" : "MISMATCH — corrupt");
+              sealed ? "verified" : "MISMATCH — corrupt");
   std::printf("  source_model_hash  %016" PRIx64 "%s\n", h.source_model_hash,
               h.source_model_hash ? "" : "  (unbound)");
   std::printf("  arena              %" PRIu64 " B (%" PRIu64 " B persistent)\n",
@@ -360,5 +361,7 @@ int main(int argc, char** argv) {
                         sizeof(UpdateInstruction), plan.size()))
       Disassemble("merge", stream(h.merge_instr_offset), h.merge_instr_count);
   }
-  return 0;
+  // The dump above is still useful forensics for a corrupt plan, but a
+  // script must not need to parse text to learn the seal failed.
+  return sealed ? 0 : 1;
 }


### PR DESCRIPTION
- kSeemlVersion 1.2.0 -> 1.0.2, matching the published tag; the tools and CMake follow via the single-sourced header.
- UpdateEngine::VerifySourceModel() + a pre-flight call in the emitted runner: a mismatched --model is refused after one file scan instead of after a full training run. Commit still re-verifies the copy it patches, so the fast path adds no TOCTOU window. New engine test.
- seeml-seeu-dump exits 1 when the plan seal is corrupt (still prints the full dump — the forensics are the tool's purpose).
- The emitted build.sh removes its .o intermediates after linking, and usage.md documents --loss-log's actual write-once-after-training behavior instead of claiming a live append.