### PR TITLE
P0: token-native export path, bit-exact resume, strict runner args

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ What SeeML can train today, stated up front:
   — token-native decoders train end to end: the corpus carries i32 token
   ids (SDS v2), next-token labels are derived from the shifted view, and
   the frozen embedding gathers on-device. The PyTorch exporter accepts an
-  `nn.Sequential` of `Linear`/activation/`LayerNorm` modules, and
-  `export_decoder_smf` emits decoder stacks from plain weight arrays. 
+  `nn.Sequential` of `Linear`/activation/`LayerNorm` modules;
+  `export_decoder_smf` emits pre-embedded decoder stacks and
+  `export_token_decoder_smf` + `export_token_sds` emit the token-native
+  form (`--demo-decoder` writes a working pair). 
   The compiler's intermediate representation additionally models 2-D convolution 
   (lowered to matrix multiplication via im2col), but
   grouped/dilated forms are rejected and the SMF container does not yet

--- a/compiler/backend/trainer/native_emitter.cc
+++ b/compiler/backend/trainer/native_emitter.cc
@@ -155,6 +155,11 @@ bool ArgsOk(int argc, char** argv) {
   static const char* const kBoolFlags[] = {"--force", "--resume", "--help",
                                            "-h"};
   for (int i = 1; i < argc; ++i) {
+    // Empty argv slots are shell debris (a quoted-but-unset "$VAR"), not
+    // typos: nothing can be misread from one, and the pre-strict runner
+    // accepted them — rejecting them would break existing wrappers for
+    // zero safety gain. They stay ignorable.
+    if (argv[i][0] == '\0') continue;
     bool known = false;
     for (const char* f : kValueFlags) {
       if (std::strcmp(argv[i], f) != 0) continue;

--- a/compiler/backend/trainer/native_emitter.cc
+++ b/compiler/backend/trainer/native_emitter.cc
@@ -137,9 +137,60 @@ bool ParseF64(const char* s, double* out) {
   return true;
 }
 
+constexpr const char* kUsage =
+    "usage: model_update --model <source.smf> --data <corpus.sds>"
+    " [--out updated.smf] [--steps N] [--seed S]"
+    " [--val-frac F] [--checkpoint ckpt] [--checkpoint-every N]"
+    " [--resume] [--loss-log curve.csv] [--force] [--help]\n";
+
+/// Every argv slot must be a known flag or a known flag's value: the
+/// compiler CLI treats unconsumed arguments as hard errors, and the device
+/// runner follows the same rule — a typo'd --val-frc must not silently
+/// train with the default.
+bool ArgsOk(int argc, char** argv) {
+  static const char* const kValueFlags[] = {
+      "--model",      "--data",     "--out",
+      "--steps",      "--seed",     "--val-frac",
+      "--checkpoint", "--loss-log", "--checkpoint-every"};
+  static const char* const kBoolFlags[] = {"--force", "--resume", "--help",
+                                           "-h"};
+  for (int i = 1; i < argc; ++i) {
+    bool known = false;
+    for (const char* f : kValueFlags) {
+      if (std::strcmp(argv[i], f) != 0) continue;
+      if (i + 1 >= argc) {
+        std::fprintf(stderr, "model_update: %s requires a value\n", argv[i]);
+        return false;
+      }
+      known = true;
+      ++i;
+      break;
+    }
+    if (!known)
+      for (const char* f : kBoolFlags)
+        if (std::strcmp(argv[i], f) == 0) {
+          known = true;
+          break;
+        }
+    if (!known) {
+      std::fprintf(stderr,
+                   "model_update: unknown argument '%s' (see --help)\n",
+                   argv[i]);
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
+  if (Has(argc, argv, "--help") || Has(argc, argv, "-h")) {
+    std::fputs(kUsage, stdout);
+    return 0;
+  }
+  if (!ArgsOk(argc, argv)) return 2;
+
   const std::string model = Arg(argc, argv, "--model", "");
   const std::string data = Arg(argc, argv, "--data", "");
   const std::string out = Arg(argc, argv, "--out", "updated_model.smf");
@@ -159,11 +210,7 @@ int main(int argc, char** argv) {
   }
 
   if (model.empty() || data.empty()) {
-    std::fprintf(stderr,
-                 "usage: model_update --model <source.smf> --data <corpus.sds>"
-                 " [--out updated.smf] [--steps N] [--seed S]"
-                 " [--val-frac F] [--checkpoint ckpt] [--checkpoint-every N]"
-                 " [--resume] [--loss-log curve.csv] [--force]\n");
+    std::fputs(kUsage, stderr);
     return 2;
   }
 

--- a/compiler/backend/trainer/native_emitter.cc
+++ b/compiler/backend/trainer/native_emitter.cc
@@ -158,7 +158,12 @@ bool ArgsOk(int argc, char** argv) {
     bool known = false;
     for (const char* f : kValueFlags) {
       if (std::strcmp(argv[i], f) != 0) continue;
-      if (i + 1 >= argc) {
+      // A '-'-prefixed value is a flag that swallowed its neighbor
+      // (`--out --force`), not a value: Arg() would take it as a filename
+      // while Has() independently still sees it as set. No legitimate
+      // value here starts with '-' (paths aside, and steps/seed/val-frac
+      // reject negatives anyway), so refuse rather than double-read.
+      if (i + 1 >= argc || argv[i + 1][0] == '-') {
         std::fprintf(stderr, "model_update: %s requires a value\n", argv[i]);
         return false;
       }
@@ -185,11 +190,15 @@ bool ArgsOk(int argc, char** argv) {
 }  // namespace
 
 int main(int argc, char** argv) {
+  // Strictness before convenience: ArgsOk first, so `--out -h` is a
+  // missing-value error rather than a help hit on a swallowed slot. After
+  // it passes, every argv slot is a known flag or a non-flag value, and
+  // Has()/Arg() below cannot double-read a slot.
+  if (!ArgsOk(argc, argv)) return 2;
   if (Has(argc, argv, "--help") || Has(argc, argv, "-h")) {
     std::fputs(kUsage, stdout);
     return 0;
   }
-  if (!ArgsOk(argc, argv)) return 2;
 
   const std::string model = Arg(argc, argv, "--model", "");
   const std::string data = Arg(argc, argv, "--data", "");

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -36,6 +36,17 @@ export_sds(inputs, labels, "corpus.sds")    # labels: int32 classes, dense f32, 
 
 The exporter accepts an `nn.Sequential` of `Linear`, `ReLU`, `GELU`, `SiLU`, and `LayerNorm` modules — anything else is a loud `ValueError`, not a silent skip. One detail worth knowing so the format makes sense later: PyTorch stores a `Linear`'s weight as `[out, in]`, but SMF's `MatMul(x, W)` wants `[in, out]`, so the exporter transposes on the way out. Labels: pass int32 class indices for cross-entropy, dense float vectors for MSE, or `None` for a distillation corpus (the teacher provides the targets).
 
+**Token-native decoders.** For a decoder transformer that consumes raw token ids (SMF v4), export the frozen embedding table alongside the blocks, and a corpus of plain ids — no labels, no embedded vectors:
+
+```python
+from export_model import export_token_decoder_smf, export_token_sds
+export_token_decoder_smf(embedding, blocks, head, "decoder.smf",
+                         seq_len=S, num_heads=H)   # embedding: [V, D] f32
+export_token_sds(records, "corpus.sds")            # records: [N, S+1] i32
+```
+
+Each corpus record is `S + 1` ids: the runtime feeds the first `S` and derives next-token labels from the shifted view, and the embedding gathers on-device. `python3 tool/export_model.py --demo-decoder out/` writes a working example of both files (NumPy only — no PyTorch needed). Remember that `--data-batch` counts *rows* (tokens), so it must be a multiple of `seq_len`.
+
 ## Step 2: Compile the Update Plan (build host)
 
 Here's a full-featured invocation; we'll unpack it flag by flag:
@@ -91,7 +102,7 @@ model_update --model model.smf --data corpus.sds --out updated.smf \
 | `--val-frac F` | held-out fraction for the regression gate (0.1); 0 gates on the training-loss trend instead |
 | `--checkpoint path` | checkpoint file, hash-bound to the plan |
 | `--checkpoint-every N` | steps between checkpoints (0 = off) |
-| `--resume` | resume from `--checkpoint` if present |
+| `--resume` | resume from `--checkpoint` if present; `--steps N` then means N *further* steps |
 | `--loss-log curve.csv` | write the per-step loss curve |
 | `--force` | commit even if the gate shows no improvement |
 
@@ -99,7 +110,7 @@ What happens, in order:
 
 1. **Load + verify** — the plan's hash is checked, then every instruction operand is bounds-validated *before anything executes*. One arena allocation, sized at compile time. A corrupt or foreign plan is refused at this door.
 2. **Split + shuffle** — the last `--val-frac` (here 10%) of the corpus is held out for validation; training batches are then served through a seeded per-epoch permutation. Same `--seed`, same batches, same bits — on any machine.
-3. **Train** — N steps of forward + backward + clip + optimizer. Interruptible: checkpoints (`--checkpoint`, `--checkpoint-every`) are hash-bound to the plan and fsync-durable, and `--resume` picks up from one, optimizer momentum and all. A non-finite loss aborts immediately rather than continuing on garbage.
+3. **Train** — N steps of forward + backward + clip + optimizer. Interruptible: checkpoints (`--checkpoint`, `--checkpoint-every`) are hash-bound to the plan and fsync-durable, and `--resume` picks up from one — optimizer momentum, step counter, *and* the data-shuffle position, which is replayed so a resumed run produces the same bits as one that was never interrupted. `--steps` after `--resume` counts further steps, not a total. A non-finite loss aborts immediately rather than continuing on garbage.
 4. **Gate** — validation loss is evaluated before and after training with the plan's eval program. No improvement → exit code 3 and the device is left *untouched* (`--force` overrides, if you must).
 5. **Merge + commit** — deltas `Δ = (α/r)·A@B` are materialized and added to the pristine f32 weights of the source file (which must hash-match the plan), written durably, renamed atomically. A power cut at any moment leaves the old model or the new one — never a torn file.
 

--- a/runtime/engine/update_engine.cc
+++ b/runtime/engine/update_engine.cc
@@ -635,7 +635,8 @@ std::expected<TrainReport, std::string> UpdateEngine::TrainImpl(
       if (!MulOk(step_, header_.batch, &served))
         return diag::executing::Error("resumed step count overflows the "
                                       "feeder position");
-      data.SkipServed(served);
+      if (auto r = data.SkipServed(served); !r)
+        return std::unexpected(r.error());
     }
   }
 

--- a/runtime/engine/update_engine.cc
+++ b/runtime/engine/update_engine.cc
@@ -619,9 +619,24 @@ std::expected<TrainReport, std::string> UpdateEngine::TrainImpl(
       return std::unexpected(r.error());
 
   if (options.resume && !options.checkpoint_path.empty()) {
-    if (auto r = LoadCheckpoint(options.checkpoint_path); !r)
+    if (auto r = LoadCheckpoint(options.checkpoint_path); !r) {
       std::fprintf(stderr, "seeml-update: no checkpoint resumed (%s)\n",
                    r.error().c_str());
+    } else if (step_ > 0) {
+      // Replay the feeder to where the interrupted run stood: step_ batches
+      // of header_.batch rows each. Without this, a resumed process serves
+      // the permutation from the top, and its batch order — hence its
+      // final bits — diverges from the same run left uninterrupted. The
+      // dataset owns the rows-to-cursor exchange rate (token corpora
+      // advance one record per seq_len rows) and replays per-epoch
+      // permutations from the shuffle seed, so the position is exact even
+      // across epoch boundaries.
+      uint64_t served = 0;
+      if (!MulOk(step_, header_.batch, &served))
+        return diag::executing::Error("resumed step count overflows the "
+                                      "feeder position");
+      data.SkipServed(served);
+    }
   }
 
   TrainReport report;

--- a/runtime/feeder/dataset.cc
+++ b/runtime/feeder/dataset.cc
@@ -390,9 +390,21 @@ void Dataset::RestoreServingPos(ServingPos pos) {
   }
 }
 
-void Dataset::SkipServed(uint64_t rows) {
-  const uint64_t records = input_kind_ == 1 ? rows / input_dim_ : rows;
+std::expected<void, std::string> Dataset::SkipServed(uint64_t rows) {
+  uint64_t records = rows;
+  if (input_kind_ == 1) {
+    // One record serves input_dim_ rows. The compiler fixes batch as a
+    // whole number of sequences, so a remainder here means the caller's
+    // step arithmetic and this corpus disagree — refuse loudly rather
+    // than silently desynchronize the replayed cursor.
+    if (rows % input_dim_ != 0)
+      return diag::feeding::Error(
+          "served rows are not a whole number of token records — cannot "
+          "replay the serving position");
+    records = rows / input_dim_;
+  }
   RestoreServingPos({records % num_samples_, records / num_samples_});
+  return {};
 }
 
 void Dataset::Reshuffle() {

--- a/runtime/feeder/dataset.cc
+++ b/runtime/feeder/dataset.cc
@@ -390,6 +390,11 @@ void Dataset::RestoreServingPos(ServingPos pos) {
   }
 }
 
+void Dataset::SkipServed(uint64_t rows) {
+  const uint64_t records = input_kind_ == 1 ? rows / input_dim_ : rows;
+  RestoreServingPos({records % num_samples_, records / num_samples_});
+}
+
 void Dataset::Reshuffle() {
   for (uint64_t i = 0; i < num_samples_; ++i) order_[i] = i;
   // Fisher–Yates with an unbiased-enough bound (num_samples << 2^64).

--- a/runtime/feeder/dataset.h
+++ b/runtime/feeder/dataset.h
@@ -106,6 +106,14 @@ class Dataset {
   /// replayed deterministically from the shuffle seed.
   void RestoreServingPos(ServingPos pos);
 
+  /// Advances the serving position as though `rows` batch rows had already
+  /// been served — the checkpoint-resume replay (the engine passes
+  /// restored_step × batch). The row-to-cursor exchange rate is the
+  /// dataset's own: token corpora serve one *record* per seq_len rows,
+  /// float corpora one sample per row. Token plans compile batch as a
+  /// whole number of sequences, so the division here is exact.
+  void SkipServed(uint64_t rows);
+
   /// Splits off the LAST `fraction` of samples (before any shuffling) as a
   /// held-out validation set, removing them from this dataset. Deterministic:
   /// the same file and fraction always produce the same split. At least one

--- a/runtime/feeder/dataset.h
+++ b/runtime/feeder/dataset.h
@@ -111,8 +111,9 @@ class Dataset {
   /// restored_step × batch). The row-to-cursor exchange rate is the
   /// dataset's own: token corpora serve one *record* per seq_len rows,
   /// float corpora one sample per row. Token plans compile batch as a
-  /// whole number of sequences, so the division here is exact.
-  void SkipServed(uint64_t rows);
+  /// whole number of sequences, so `rows` must divide into whole records;
+  /// a remainder is an error, never a silent truncation.
+  [[nodiscard]] std::expected<void, std::string> SkipServed(uint64_t rows);
 
   /// Splits off the LAST `fraction` of samples (before any shuffling) as a
   /// held-out validation set, removing them from this dataset. Deterministic:

--- a/test/runtime/engine/update_engine_test.cc
+++ b/test/runtime/engine/update_engine_test.cc
@@ -399,6 +399,47 @@ TEST(UpdateEngineCheckpoint, RoundTripRestoresPersistentState) {
   EXPECT_EQ(std::memcmp(engine.arena(), saved.data(), saved.size()), 0);
 }
 
+TEST(UpdateEngineCheckpoint, ResumedRunMatchesUninterruptedRunBitwise) {
+  ScopedTempDir dir;
+  const std::vector<uint8_t> plan = CompilePlan(BaseConfig(kBatch));
+  ASSERT_FALSE(plan.empty());
+
+  // The uninterrupted twin: 6 steps over a shuffled feeder.
+  UpdateEngine straight;
+  ASSERT_OK(straight.LoadFromMemory(plan.data(), plan.size()));
+  ASSERT_OK_AND_ASSIGN(Dataset d1, MakeClassificationData(10, kInDim, 5));
+  d1.EnableShuffle(42);
+  ASSERT_OK(straight.Train(d1, 6, Quiet()));
+
+  // The interrupted twin: 3 steps, checkpoint, process death — then a cold
+  // resume (fresh engine, freshly loaded feeder) for 3 more. With 10
+  // samples the feeder crosses an epoch boundary mid-way, so the resumed
+  // serving position must replay a reshuffle, not just a cursor.
+  const std::string ck = dir.File("ck.bin");
+  {
+    UpdateEngine first;
+    ASSERT_OK(first.LoadFromMemory(plan.data(), plan.size()));
+    ASSERT_OK_AND_ASSIGN(Dataset d2, MakeClassificationData(10, kInDim, 5));
+    d2.EnableShuffle(42);
+    ASSERT_OK(first.Train(d2, 3, Quiet()));
+    ASSERT_OK(first.SaveCheckpoint(ck));
+  }
+  UpdateEngine resumed;
+  ASSERT_OK(resumed.LoadFromMemory(plan.data(), plan.size()));
+  ASSERT_OK_AND_ASSIGN(Dataset d3, MakeClassificationData(10, kInDim, 5));
+  d3.EnableShuffle(42);
+  TrainOptions opt = Quiet();
+  opt.checkpoint_path = ck;
+  opt.resume = true;
+  ASSERT_OK(resumed.Train(d3, 3, opt));
+  EXPECT_EQ(resumed.step(), 6u);
+
+  // "Power cuts are ordinary": the resumed run and the uninterrupted run
+  // must be the same run, bit for bit.
+  EXPECT_EQ(std::memcmp(straight.arena(), resumed.arena(),
+                        straight.header().persistent_size), 0);
+}
+
 TEST(UpdateEngineCheckpoint, RejectsIncompatibleCheckpoint) {
   ScopedTempDir dir;
   const std::vector<uint8_t> plan = CompilePlan(BaseConfig(kBatch));

--- a/test/runtime/engine/update_engine_test.cc
+++ b/test/runtime/engine/update_engine_test.cc
@@ -432,6 +432,9 @@ TEST(UpdateEngineCheckpoint, ResumedRunMatchesUninterruptedRunBitwise) {
   opt.checkpoint_path = ck;
   opt.resume = true;
   ASSERT_OK(resumed.Train(d3, 3, opt));
+  // Both engines must actually have trained to step 6 — otherwise the byte
+  // comparison below could pass vacuously on two equally-early states.
+  EXPECT_EQ(straight.step(), 6u);
   EXPECT_EQ(resumed.step(), 6u);
 
   // "Power cuts are ordinary": the resumed run and the uninterrupted run

--- a/test/system/update_system_test.cc
+++ b/test/system/update_system_test.cc
@@ -687,6 +687,11 @@ TEST(UpdateSystem, TokenDecoderResumeMatchesUninterruptedRun) {
   opt.checkpoint_path = ck;
   opt.resume = true;
   ASSERT_OK(resumed.Train(d3, 3, opt));
+
+  // Guard against a vacuous pass: both engines must actually have trained
+  // to step 6 before the byte comparison means anything.
+  EXPECT_EQ(straight.step(), 6u);
+  EXPECT_EQ(resumed.step(), 6u);
   EXPECT_EQ(std::memcmp(straight.arena(), resumed.arena(),
                         straight.header().persistent_size),
             0);

--- a/test/system/update_system_test.cc
+++ b/test/system/update_system_test.cc
@@ -644,6 +644,54 @@ TEST(UpdateSystem, TokenDecoderGradientsMatchFiniteDifferences) {
   GradientCheck(compiled, engine, 3737, /*tol=*/3e-2);
 }
 
+TEST(UpdateSystem, TokenDecoderResumeMatchesUninterruptedRun) {
+  const int64_t vocab = 16, dim = 8, heads = 2, seq = 4, ffn = 16;
+  const int64_t batch = 16;  // 4 records per step: on resume the feeder
+                             // must advance in records, not rows
+  SmfModel model =
+      seeml::testing::MakeTinyTokenDecoder(vocab, dim, heads, seq, ffn, 41);
+  UpdateConfig config = BaseConfig(batch);
+  ASSERT_OK_AND_ASSIGN(CompiledUpdate compiled,
+                       UpdateCompiler(config).Compile(model));
+
+  // The uninterrupted twin: 6 steps over a shuffled 10-record corpus, so
+  // step 3 crosses an epoch boundary and the replay covers a reshuffle.
+  UpdateEngine straight;
+  ASSERT_OK(
+      straight.LoadFromMemory(compiled.plan.data(), compiled.plan.size()));
+  ASSERT_OK_AND_ASSIGN(Dataset d1,
+                       seeml::testing::MakeTokenCorpus(10, seq, vocab, 43));
+  d1.EnableShuffle(7);
+  ASSERT_OK(straight.Train(d1, 6, Quiet()));
+
+  // The interrupted twin: 3 steps, checkpoint, process death, cold resume.
+  ScopedTempDir dir;
+  const std::string ck = dir.File("ck.bin");
+  {
+    UpdateEngine first;
+    ASSERT_OK(
+        first.LoadFromMemory(compiled.plan.data(), compiled.plan.size()));
+    ASSERT_OK_AND_ASSIGN(Dataset d2,
+                         seeml::testing::MakeTokenCorpus(10, seq, vocab, 43));
+    d2.EnableShuffle(7);
+    ASSERT_OK(first.Train(d2, 3, Quiet()));
+    ASSERT_OK(first.SaveCheckpoint(ck));
+  }
+  UpdateEngine resumed;
+  ASSERT_OK(
+      resumed.LoadFromMemory(compiled.plan.data(), compiled.plan.size()));
+  ASSERT_OK_AND_ASSIGN(Dataset d3,
+                       seeml::testing::MakeTokenCorpus(10, seq, vocab, 43));
+  d3.EnableShuffle(7);
+  TrainOptions opt = Quiet();
+  opt.checkpoint_path = ck;
+  opt.resume = true;
+  ASSERT_OK(resumed.Train(d3, 3, opt));
+  EXPECT_EQ(std::memcmp(straight.arena(), resumed.arena(),
+                        straight.header().persistent_size),
+            0);
+}
+
 TEST(UpdateSystem, TokenDecoderTrainsMergesAndCommits) {
   const int64_t vocab = 16, dim = 8, heads = 2, seq = 4, ffn = 16;
   const int64_t batch = 16;  // 4 sequences per step

--- a/tool/README.md
+++ b/tool/README.md
@@ -18,10 +18,13 @@ tool/
 ## What each one is for
 
 **`export_model.py`** is the on-ramp: it converts a PyTorch `nn.Sequential`
-(or a decoder stack) into the SMF model container and turns arrays into an
-SDS corpus — the only Python in the product, and the only place PyTorch and
-NumPy are needed (`pip install -r tool/requirements.txt`). Everything
-downstream is dependency-free C++.
+(or a decoder stack — pre-embedded via `export_decoder_smf`, or token-native
+SMF v4 via `export_token_decoder_smf` + `export_token_sds`) into the SMF
+model container and turns arrays into an SDS corpus — the only Python in
+the product, and the only place PyTorch and NumPy are needed
+(`pip install -r tool/requirements.txt`; the token-native path and
+`--demo-decoder` need NumPy only). Everything downstream is
+dependency-free C++.
 
 **`seeml_update_compile.cc`** is the compiler itself as a command: source
 model in, `.seeu` plan (and optional self-contained native package) out. Its

--- a/tool/export_model.py
+++ b/tool/export_model.py
@@ -315,6 +315,9 @@ def export_token_sds(records, path: str):
     a = np.ascontiguousarray(np.asarray(records, dtype=np.int32))
     if a.ndim != 2 or a.shape[1] < 2:
         raise ValueError("export_token_sds: records must be [N, seq_len + 1]")
+    if a.shape[0] == 0:
+        raise ValueError("export_token_sds: no records — an empty corpus "
+                         "would only fail later, at on-device load")
     if (a < 0).any():
         raise ValueError("export_token_sds: negative token id")
     n, s = a.shape[0], a.shape[1] - 1
@@ -369,8 +372,9 @@ def _demo_decoder(out_dir: str):
     export_token_sds(records.astype(np.int32),
                      f"{out_dir}/decoder_corpus.sds")
     print(f"try: seeml-update-compile --source {out_dir}/decoder.smf"
-          f" --data-batch {4 * seq} --loss xent --lora-rank 4"
-          " --lora-alpha 8 --optimizer adamw --lr 2e-3 --steps 600")
+          f" --out {out_dir}/pkg/ --data-batch {4 * seq} --loss xent"
+          " --lora-rank 4 --lora-alpha 8 --optimizer adamw --lr 2e-3"
+          " --steps 600 --build")
 
 
 if __name__ == "__main__":

--- a/tool/export_model.py
+++ b/tool/export_model.py
@@ -9,9 +9,18 @@ Usage:
     python3 export_model.py --demo out_dir/
         Writes a demo model.smf, teacher.smf and corpus.sds for a smoke run.
 
+    python3 export_model.py --demo-decoder out_dir/
+        Writes a token-native demo decoder.smf (SMF v4) and its
+        decoder_corpus.sds (SDS v2, i32 token ids). NumPy only.
+
     from export_model import export_smf, export_sds
         export_smf(torch_sequential, "model.smf")
         export_sds(inputs, labels, "corpus.sds")
+
+    from export_model import export_token_decoder_smf, export_token_sds
+        export_token_decoder_smf(embedding, blocks, head, "model.smf",
+                                 seq_len=S, num_heads=H)
+        export_token_sds(token_records, "corpus.sds")  # [N, S+1] i32
 
 Supported modules inside an nn.Sequential:
     nn.Linear     -> MatMul(x, W[in,out]) + AddBias(b[out])  (W stored
@@ -33,6 +42,7 @@ ALIGN = 64
 
 (OP_MATMUL, OP_ADDBIAS, OP_RELU, OP_GELU, OP_SILU, OP_MUL, OP_LAYERNORM,
  OP_ADD, OP_RMSNORM, OP_ROPE, OP_ATTENTION) = range(11)
+OP_EMBEDDING = 11  # SMF v4: gather table rows by the model's i32 token input
 
 
 def _align(n: int) -> int:
@@ -45,13 +55,16 @@ def _s(name: str) -> bytes:
 
 
 class _SmfBuilder:
-    def __init__(self, input_name: str, input_dim: int, seq_len: int = 0):
+    def __init__(self, input_name: str, input_dim: int, seq_len: int = 0,
+                 token_input: bool = False):
         self.input_name = input_name
         self.output_name = input_name
         self.seq_len = seq_len  # rows per sequence; 0 = non-sequential
-        self.tensors = [
-            dict(name=input_name, dims=[-1, input_dim], const=False, data=b"")
-        ]
+        # A token-native model (SMF v4) declares a rank-1 dynamic input:
+        # one i32 token id per row, gathered on-device by kEmbedding.
+        self.version = 4 if token_input else SMF_VERSION
+        dims = [-1] if token_input else [-1, input_dim]
+        self.tensors = [dict(name=input_name, dims=dims, const=False, data=b"")]
         self.ops = []
 
     def add_tensor(self, name, dims, data: bytes):
@@ -64,7 +77,7 @@ class _SmfBuilder:
 
     def serialize(self) -> bytes:
         def meta(offsets):
-            out = struct.pack("<IIII", SMF_MAGIC, SMF_VERSION,
+            out = struct.pack("<IIII", SMF_MAGIC, self.version,
                               len(self.tensors), len(self.ops))
             out += _s(self.input_name) + _s(self.output_name)
             out += struct.pack("<Q", self.seq_len)
@@ -157,33 +170,23 @@ def export_smf(model, path: str, input_name: str = "x"):
     print(f"wrote {path} ({idx} linear layers)")
 
 
-def export_decoder_smf(blocks, head, path: str, seq_len: int, num_heads: int,
-                       input_name: str = "x"):
-    """Export a pre-norm causal decoder stack to SMF v3.
-
-    `blocks` is a list of dicts of float32 numpy arrays, one per layer:
-        ln1_g [D]; wq, wk, wv, wo [D, D]; ln2_g [D];
-        w_gate, w_up [D, F]; w_down [F, D]
-    `head` is {"lnf_g": [D], "w_head": [D, V]}. Rows of the runtime input
-    are pre-embedded hidden states [T = B*seq_len, D] (embedding lookup is
-    outside the update scope — the corpus carries embedded vectors).
-    Requires D % num_heads == 0 and (D // num_heads) % 2 == 0 (RoPE pairs).
-    """
-    import numpy as np
-
+def _decoder_dim(blocks, head, num_heads: int, caller: str) -> int:
     D = int(blocks[0]["wq"].shape[0]) if blocks else int(head["w_head"].shape[0])
     if D % num_heads != 0 or (D // num_heads) % 2 != 0:
-        raise ValueError("export_decoder_smf: num_heads must divide D and "
+        raise ValueError(f"{caller}: num_heads must divide D and "
                          "leave an even head width for RoPE")
+    return D
 
-    b = _SmfBuilder(input_name, D, seq_len=seq_len)
+
+def _emit_decoder_graph(b, blocks, head, num_heads: int, prev: str):
+    """Append the pre-norm block stack and lm head, reading rows from `prev`."""
+    import numpy as np
 
     def tensor(name, arr):
         a = np.ascontiguousarray(np.asarray(arr, dtype=np.float32))
         b.add_tensor(name, list(a.shape), a.tobytes())
         return name
 
-    prev = input_name
     for i, blk in enumerate(blocks):
         p = f"l{i}."
         tensor(p + "ln1_g", blk["ln1_g"])
@@ -216,10 +219,57 @@ def export_decoder_smf(blocks, head, path: str, seq_len: int, num_heads: int,
     tensor("w_head", head["w_head"])
     b.add_op(OP_MATMUL, "mm_head", ["nf", "w_head"], "logits")
 
+
+def export_decoder_smf(blocks, head, path: str, seq_len: int, num_heads: int,
+                       input_name: str = "x"):
+    """Export a pre-norm causal decoder stack to SMF v3.
+
+    `blocks` is a list of dicts of float32 numpy arrays, one per layer:
+        ln1_g [D]; wq, wk, wv, wo [D, D]; ln2_g [D];
+        w_gate, w_up [D, F]; w_down [F, D]
+    `head` is {"lnf_g": [D], "w_head": [D, V]}. Rows of the runtime input
+    are pre-embedded hidden states [T = B*seq_len, D] (embedding lookup is
+    outside the update scope — the corpus carries embedded vectors). For a
+    model that consumes raw token ids instead, use export_token_decoder_smf.
+    Requires D % num_heads == 0 and (D // num_heads) % 2 == 0 (RoPE pairs).
+    """
+    D = _decoder_dim(blocks, head, num_heads, "export_decoder_smf")
+    b = _SmfBuilder(input_name, D, seq_len=seq_len)
+    _emit_decoder_graph(b, blocks, head, num_heads, prev=input_name)
     with open(path, "wb") as f:
         f.write(b.serialize())
     print(f"wrote {path} ({len(blocks)} decoder blocks, seq_len={seq_len}, "
           f"heads={num_heads})")
+
+
+def export_token_decoder_smf(embedding, blocks, head, path: str, seq_len: int,
+                             num_heads: int, input_name: str = "x"):
+    """Export a token-native pre-norm causal decoder to SMF v4.
+
+    Same `blocks` / `head` dictionaries as export_decoder_smf, plus
+    `embedding`: a float32 [V, D] table. The exported model's input is a
+    rank-1 i32 row of token ids; the frozen table gathers on-device
+    (kEmbedding), so the corpus stays token ids (export_token_sds) and
+    never carries embedded vectors. The table itself is frozen — LoRA
+    adapters attach to the projection matmuls as usual.
+    """
+    import numpy as np
+
+    emb = np.ascontiguousarray(np.asarray(embedding, dtype=np.float32))
+    if emb.ndim != 2:
+        raise ValueError("export_token_decoder_smf: embedding must be [V, D]")
+    D = _decoder_dim(blocks, head, num_heads, "export_token_decoder_smf")
+    if int(emb.shape[1]) != D:
+        raise ValueError("export_token_decoder_smf: embedding width "
+                         f"{emb.shape[1]} does not match block width {D}")
+    b = _SmfBuilder(input_name, D, seq_len=seq_len, token_input=True)
+    b.add_tensor("emb", list(emb.shape), emb.tobytes())
+    b.add_op(OP_EMBEDDING, "embed", [input_name, "emb"], "e")
+    _emit_decoder_graph(b, blocks, head, num_heads, prev="e")
+    with open(path, "wb") as f:
+        f.write(b.serialize())
+    print(f"wrote {path} ({len(blocks)} decoder blocks, seq_len={seq_len}, "
+          f"heads={num_heads}, vocab={emb.shape[0]}, token-native)")
 
 
 def export_sds(inputs, labels, path: str, label_kind: int = 1):
@@ -252,6 +302,28 @@ def export_sds(inputs, labels, path: str, label_kind: int = 1):
     print(f"wrote {path} ({n} samples, input_dim={d}, label_kind={label_kind})")
 
 
+def export_token_sds(records, path: str):
+    """Export a token corpus to SDS v2 (for token-native SMF v4 models).
+
+    `records`: int32 array [N, S + 1] — N training records of S + 1 token
+    ids each, where S is the model's compiled seq_len. No labels are
+    stored: the runtime derives next-token class labels from the shifted
+    view (record[1:] labels record[:-1]).
+    """
+    import numpy as np
+
+    a = np.ascontiguousarray(np.asarray(records, dtype=np.int32))
+    if a.ndim != 2 or a.shape[1] < 2:
+        raise ValueError("export_token_sds: records must be [N, seq_len + 1]")
+    if (a < 0).any():
+        raise ValueError("export_token_sds: negative token id")
+    n, s = a.shape[0], a.shape[1] - 1
+    with open(path, "wb") as f:
+        f.write(struct.pack("<IIQQIIQ", SDS_MAGIC, 2, n, s, 1, 1, 0))
+        f.write(a.tobytes())
+    print(f"wrote {path} ({n} records, seq_len={s}, token-native)")
+
+
 def _demo(out_dir: str):
     import numpy as np
     import torch
@@ -269,15 +341,54 @@ def _demo(out_dir: str):
     export_sds(x, y, f"{out_dir}/corpus.sds")
 
 
+def _demo_decoder(out_dir: str):
+    """A tiny token-native decoder plus a corpus it can actually learn:
+    a cyclic-successor language where token t is always followed by
+    (t + 3) % vocab. Needs NumPy only — no PyTorch."""
+    import numpy as np
+
+    rng = np.random.default_rng(0)
+    vocab, dim, heads, seq, ffn = 50, 32, 4, 8, 64
+
+    def mat(rows, cols):
+        return (rng.standard_normal((rows, cols)) * 0.15).astype(np.float32)
+
+    blocks = [{
+        "ln1_g": np.ones(dim, np.float32), "wq": mat(dim, dim),
+        "wk": mat(dim, dim), "wv": mat(dim, dim), "wo": mat(dim, dim),
+        "ln2_g": np.ones(dim, np.float32), "w_gate": mat(dim, ffn),
+        "w_up": mat(dim, ffn), "w_down": mat(ffn, dim),
+    } for _ in range(2)]
+    head = {"lnf_g": np.ones(dim, np.float32), "w_head": mat(dim, vocab)}
+    emb = (rng.standard_normal((vocab, dim)) * 0.5).astype(np.float32)
+    export_token_decoder_smf(emb, blocks, head, f"{out_dir}/decoder.smf",
+                             seq_len=seq, num_heads=heads)
+
+    starts = rng.integers(0, vocab, 192)
+    records = (starts[:, None] + 3 * np.arange(seq + 1)) % vocab
+    export_token_sds(records.astype(np.int32),
+                     f"{out_dir}/decoder_corpus.sds")
+    print(f"try: seeml-update-compile --source {out_dir}/decoder.smf"
+          f" --data-batch {4 * seq} --loss xent --lora-rank 4"
+          " --lora-alpha 8 --optimizer adamw --lr 2e-3 --steps 600")
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--demo", metavar="OUT_DIR",
                         help="emit a demo model/teacher/corpus into OUT_DIR")
+    parser.add_argument("--demo-decoder", metavar="OUT_DIR",
+                        help="emit a token-native demo decoder/corpus "
+                             "into OUT_DIR (NumPy only, no PyTorch)")
     args = parser.parse_args()
-    if not args.demo:
+    if not args.demo and not args.demo_decoder:
         parser.print_help()
         sys.exit(0)
     import os
 
-    os.makedirs(args.demo, exist_ok=True)
-    _demo(args.demo)
+    if args.demo:
+        os.makedirs(args.demo, exist_ok=True)
+        _demo(args.demo)
+    if args.demo_decoder:
+        os.makedirs(args.demo_decoder, exist_ok=True)
+        _demo_decoder(args.demo_decoder)


### PR DESCRIPTION
## Summary

The three P0 items from the release deep-probe: make the headline token-native feature reachable from the shipped tooling, make checkpoint resume bit-exact, and make the emitted runner argument-strict.

**1. Token-native export path (SMF v4 / SDS v2 from Python).** `export_model.py` gains `export_token_decoder_smf(embedding, blocks, head, ...)` — same block/head dictionaries as `export_decoder_smf`, plus a `[V, D]` frozen embedding table; emits SMF v4 with a rank-1 i32 input and a leading `kEmbedding` gather — and `export_token_sds(records)` for `[N, seq_len+1]` i32 corpora (SDS v2, labels derived on-device from the shifted view). A new `--demo-decoder OUT_DIR` mode writes a working pair (NumPy only, no PyTorch) that trains to 100% validation accuracy on its cyclic-successor language. The shared decoder emission is factored into `_emit_decoder_graph`; `export_decoder_smf` behavior is unchanged. Previously SMF v4 models could only be built by the C++ test fixtures.

**2. Resumed runs now reproduce uninterrupted runs bit-for-bit.** The checkpoint restores adapters, moments, and step — but the feeder always re-served the permutation from the top, so a resumed run's batch order (and final bits) diverged from the same run left uninterrupted. On resume the engine now replays the serving position: new `Dataset::SkipServed(rows)` converts served rows to cursor records at the dataset's own exchange rate (token corpora advance one record per seq_len rows — the first cut multiplied by `header_.batch` and over-advanced token feeders) and reuses `RestoreServingPos`'s deterministic per-epoch permutation replay. Covered by `UpdateEngineCheckpoint.ResumedRunMatchesUninterruptedRunBitwise` (float path) and `UpdateSystem.TokenDecoderResumeMatchesUninterruptedRun` (token path, epoch-crossing), both comparing persistent arenas byte-for-byte.

**3. Strict arguments in the emitted `model_update`.** Unknown flags (`--val-frc`) and value-flags missing their value are now hard errors (exit 2) instead of silently training with defaults, matching the compiler CLI's discipline; `--help`/`-h` prints usage and exits 0.

Docs: usage.md documents the token-native export, that `--steps` after `--resume` counts *further* steps, and the resume bit-exactness guarantee; tool/README.md and README's scope section name the new functions; the exporter's module docstring shows both new entry points.

## Testing

- Full clean build (`-Wall -Wextra -Werror`), all 25 suites pass including the two new resume tests.
- End-to-end: `--demo-decoder` → compile → train reaches 100% validation accuracy and commits; straight-400 vs 200+resume-200 committed models are byte-identical (`cmp`) for both the token decoder and the MLP demo package; typo'd flags exit 2 with a pointer to `--help`.

## Note for a follow-up

`--checkpoint path` without `--checkpoint-every N` never writes a checkpoint (every defaults to 0 = off) — documented, but arguably surprising; a follow-up could default `--checkpoint-every` to a sane value whenever `--checkpoint` is given.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review-fix addendum (467bb57)

A workflow-backed high-effort code review of this branch surfaced seven findings; six are fixed in the follow-up commit (runner value-flags refuse '-'-prefixed values and strictness now precedes the --help check; Dataset::SkipServed errors on a non-whole record count; both resume tests assert step()==6; export_token_sds rejects empty record arrays; the --demo-decoder hint now includes --out/--build and runs as pasted). The seventh (consolidating the runner's triplicated flag inventory) is deferred as a follow-up refactor.
