### PR TITLE
Benchmark harness: seeml-bench, nightly Tier A gate, step-latency instrumentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
   # only from 19 (Ubuntu's clang 18.1 + noble's pre-14.1 libstdc++ can
   # never see the template). Pinning turns runner-image rotations from
   # red builds into non-events.
+  #
+  # Every toolchain-install step is bounded (wget read-timeout, 3 retries,
+  # step timeout-minutes): apt.llvm.org throttles the Actions IP space at
+  # times, and an unbounded fetch turns that stall into the whole job
+  # budget (observed 2026-08-19: four jobs dead at their ceilings without
+  # compiling a line). A stall now costs minutes and usually self-heals.
   build-and-test:
     name: test (${{ matrix.os }}, ${{ matrix.cxx }})
     strategy:
@@ -57,9 +63,17 @@ jobs:
       - uses: actions/checkout@v4
       - name: Pin the Linux toolchain
         if: runner.os == 'Linux'
+        timeout-minutes: 8
         run: |
-          sudo apt-get update -q && sudo apt-get install -y -q g++-14
-          wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all
+          for i in 1 2 3; do
+            if sudo apt-get update -q && sudo apt-get install -y -q g++-14 &&
+               wget -T 30 -t 1 -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all; then
+              exit 0
+            fi
+            echo "toolchain install attempt $i failed; retrying" >&2
+            sleep 20
+          done
+          exit 1
       - name: Toolchain version
         run: $CXX --version
       - name: Build (shell driver, no CMake)
@@ -87,7 +101,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Pin the Linux toolchain
-        run: wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all
+        timeout-minutes: 6
+        run: |
+          for i in 1 2 3; do
+            if wget -T 30 -t 1 -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all; then
+              exit 0
+            fi
+            echo "apt.llvm.org attempt $i failed; retrying" >&2
+            sleep 20
+          done
+          exit 1
       - name: Build
         run: sh build/build.sh
       - name: Run all suites at each width
@@ -120,7 +143,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Pin the Linux toolchain
-        run: wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all
+        timeout-minutes: 6
+        run: |
+          for i in 1 2 3; do
+            if wget -T 30 -t 1 -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all; then
+              exit 0
+            fi
+            echo "apt.llvm.org attempt $i failed; retrying" >&2
+            sleep 20
+          done
+          exit 1
       - name: Configure
         run: >
           cmake -S . -B build-san
@@ -145,7 +177,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Pin the Linux toolchain
-        run: wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all
+        timeout-minutes: 6
+        run: |
+          for i in 1 2 3; do
+            if wget -T 30 -t 1 -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all; then
+              exit 0
+            fi
+            echo "apt.llvm.org attempt $i failed; retrying" >&2
+            sleep 20
+          done
+          exit 1
       - name: Configure
         run: cmake -S . -B build-fuzz -DSEEML_FUZZ=ON
       - name: Build harness
@@ -183,7 +224,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Pin the Linux toolchain
-        run: wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all
+        timeout-minutes: 6
+        run: |
+          for i in 1 2 3; do
+            if wget -T 30 -t 1 -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all; then
+              exit 0
+            fi
+            echo "apt.llvm.org attempt $i failed; retrying" >&2
+            sleep 20
+          done
+          exit 1
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,16 @@ jobs:
           languages: c-cpp
           queries: security-and-quality
       - name: Pin the Linux toolchain
-        run: wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all
+        timeout-minutes: 6
+        run: |
+          for i in 1 2 3; do
+            if wget -T 30 -t 1 -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all; then
+              exit 0
+            fi
+            echo "apt.llvm.org attempt $i failed; retrying" >&2
+            sleep 20
+          done
+          exit 1
       - name: Build (traced)
         run: sh build/build.sh
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Pin the Linux toolchain
-        run: wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all
+        timeout-minutes: 6
+        run: |
+          for i in 1 2 3; do
+            if wget -T 30 -t 1 -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all; then
+              exit 0
+            fi
+            echo "apt.llvm.org attempt $i failed; retrying" >&2
+            sleep 20
+          done
+          exit 1
       - name: Configure
         run: >
           cmake -S . -B build-tsan
@@ -56,7 +65,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Pin the Linux toolchain
-        run: wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all
+        timeout-minutes: 6
+        run: |
+          for i in 1 2 3; do
+            if wget -T 30 -t 1 -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all; then
+              exit 0
+            fi
+            echo "apt.llvm.org attempt $i failed; retrying" >&2
+            sleep 20
+          done
+          exit 1
       - name: Restore corpus
         uses: actions/cache@v4
         with:
@@ -95,7 +113,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Pin the Linux toolchain
-        run: wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all
+        timeout-minutes: 6
+        run: |
+          for i in 1 2 3; do
+            if wget -T 30 -t 1 -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all; then
+              exit 0
+            fi
+            echo "apt.llvm.org attempt $i failed; retrying" >&2
+            sleep 20
+          done
+          exit 1
       - name: Restore baseline
         uses: actions/cache@v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,6 +9,9 @@
 #                     turning "bounded behavior" from assertion into proof
 #   extended fuzz     15 minutes over the four untrusted-input arms, with
 #                     the corpus carried between runs via the actions cache
+#   bench             the Tier A throughput gate: seeml-bench against the
+#                     previous night's cached baseline, >10% rows/s
+#                     regression fails (docs/benchmarks.md)
 #
 # A nightly failure is a regression on main itself, not on a diff — treat
 # it with the same severity as a red PR.
@@ -75,4 +78,47 @@ jobs:
         with:
           name: nightly-fuzz-crashes
           path: crash-*
+          if-no-files-found: ignore
+
+  # The Tier A regression gate of docs/benchmarks.md: run the harness, diff
+  # against the previous night's numbers (carried by the actions cache, the
+  # fuzz-corpus trust model), fail on a >10% rows/s regression, then store
+  # this run as the next baseline. Per-commit trend on one host class — a
+  # cloud runner is noisy, which is why the gate is 10%, medians-of-3, and
+  # nightly rather than per-diff.
+  bench:
+    name: bench (Tier A regression gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CXX: clang++-19
+    steps:
+      - uses: actions/checkout@v4
+      - name: Pin the Linux toolchain
+        run: wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- 19 all
+      - name: Restore baseline
+        uses: actions/cache@v4
+        with:
+          path: bench-baseline
+          key: bench-baseline-${{ github.run_id }}
+          restore-keys: bench-baseline-
+      - name: Configure
+        run: >
+          cmake -S . -B build-bench
+          -DCMAKE_BUILD_TYPE=Release
+          -DSEEML_BENCH=ON
+      - name: Build harness
+        run: cmake --build build-bench -j "$(nproc)" --target seeml-bench
+      - name: Bench
+        run: ./build-bench/seeml-bench --out bench.json --threads 1,2,4
+      - name: Gate against baseline
+        run: python3 tool/bench_compare.py bench-baseline/bench.json bench.json
+      - name: Store as next baseline
+        run: mkdir -p bench-baseline && cp bench.json bench-baseline/bench.json
+      - name: Upload run
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-bench
+          path: bench.json
           if-no-files-found: ignore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,12 @@ endif()
 # -DSEEML_FUZZ=ON builds seeml_fuzz_formats.
 option(SEEML_FUZZ "Build the libFuzzer format-parser harness" OFF)
 
+# Benchmark harness (docs/benchmarks.md): -DSEEML_BENCH=ON builds the
+# seeml-bench tool and compiles the runtime with SEEML_STEP_TIMING, the
+# per-phase (fwd/bwd/optimizer) step clock. Default builds — and every
+# emitted package — carry neither.
+option(SEEML_BENCH "Build seeml-bench with step-latency instrumentation" OFF)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 find_package(Threads REQUIRED)
@@ -172,6 +178,15 @@ target_link_libraries(seeml_testing PUBLIC seeml_update seeml_update_rt)
 # The emitter suite vendors runtime sources out of the repository checkout.
 target_compile_definitions(seeml_testing
     PUBLIC SEEML_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}")
+
+# The benchmark harness compiles the shared seeded fixtures, so it links
+# seeml_testing; it lives here, after that target, rather than with the
+# other tools. See docs/benchmarks.md for the metric program it measures.
+if(SEEML_BENCH)
+    target_compile_definitions(seeml_update_rt PRIVATE SEEML_STEP_TIMING)
+    add_executable(seeml-bench tool/seeml_bench.cc)
+    target_link_libraries(seeml-bench PRIVATE seeml_update seeml_testing)
+endif()
 
 function(seeml_add_test name src)
     add_executable(${name} ${src} test/framework/seetest_main.cc)

--- a/build/build.sh
+++ b/build/build.sh
@@ -5,6 +5,11 @@ set -e
 cd "$(dirname "$0")/.."
 CXX="${CXX:-c++}"
 FLAGS="-std=c++23 -O2 -Wall -Wextra -Werror -pthread -I. -DSEEML_SOURCE_DIR='\"$(pwd)\"'"
+# SEEML_BENCH=1 mirrors CMake's -DSEEML_BENCH=ON: compiles the runtime with
+# the per-phase step clock and links the seeml-bench harness at the end.
+if [ -n "${SEEML_BENCH:-}" ]; then
+  FLAGS="$FLAGS -DSEEML_STEP_TIMING"
+fi
 
 compile() { echo "  CXX $1"; eval "$CXX $FLAGS -c '$1' -o 'build/$2'"; }
 
@@ -111,6 +116,14 @@ eval "$CXX -pthread build/seeml_update_compile.o $LIBS -o build/seeml-update-com
 echo "  LINK seeml-seeu-dump"
 # PlanSelfHash (the v4 integrity seal) runs on the parallel substrate.
 eval "$CXX -pthread build/seeml_seeu_dump.o build/parallel_for.o -o build/seeml-seeu-dump"
+
+if [ -n "${SEEML_BENCH:-}" ]; then
+  echo "  CXX+LINK seeml-bench"
+  eval "$CXX $FLAGS -c tool/seeml_bench.cc -o build/seeml_bench.o"
+  eval "$CXX -pthread build/seeml_bench.o build/fixtures_models.o \
+        build/fixtures_corpora.o build/fixtures_probes.o \
+        $LIBS $METAL_OBJS $METAL_LDFLAGS -o build/seeml-bench"
+fi
 
 for suite in \
     source/identity/hash_test source/parallel/parallel_for_test \

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -79,14 +79,44 @@ steps to 0.7× loss in ~2 s; serial vs 8-thread committed models are
 bitwise identical (the determinism overhead is therefore *measurable as
 pure speedup*, no correctness tax).
 
-## What to build next for this program
+## The harness
 
-1. A `tool/seeml_bench.cc` harness: compiles the standard fixture set,
-   runs Tier A/B sweeps with pinned seeds, and emits one JSON per run —
-   the same strict-CLI discipline as the other tools.
-2. A CI `bench` job (nightly, not per-diff): runs the harness, diffs
-   against the cached baseline artifact, and fails on >10% regression in
-   any Tier A metric — the same trust model as the fuzz corpus cache.
-3. The step-latency instrumentation: three timestamps around the
-   train/eval/merge program boundaries in `ExecuteTrainOnce`, behind a
-   compile-time flag so the shipped runtime stays untouched.
+All three pieces of this program exist:
+
+1. **`tool/seeml_bench.cc`** compiles the standard fixture set in-process
+   (the seeded builders the test suites share — two MLP stacks, three
+   4-block decoders, one token-native decoder) and emits one JSON per run:
+
+   ```bash
+   cmake -B build -DSEEML_BENCH=ON && cmake --build build --target seeml-bench
+   # or: SEEML_BENCH=1 sh build/build.sh
+   ./build/seeml-bench --out bench.json --threads 1,2,4,8
+   ```
+
+   Per fixture, per thread width: per-step latency and fixed lifecycle
+   cost by **steps-regression** (train `--steps-lo` then `--steps-hi`;
+   slope = per-step, intercept = lifecycle — startup never pollutes the
+   step number), Tier A `rows_per_s`, effective GEMM GFLOP/s (the FLOPs
+   are summed from the plan's own instruction stream, 2·M·N·K over every
+   GEMM), the fwd/bwd/optimizer split, and the Tier D lifecycle numbers
+   (compile, load+validate, merge, checkpoint save). Medians of
+   `--repeats` (default 3); seeds and thread widths pinned. The CLI is
+   strict, like the other tools: an unknown flag or a flag that cannot
+   parse is exit 2, never a default.
+
+2. **The nightly `bench` CI job** restores the previous night's numbers
+   from the actions cache (the fuzz-corpus trust model), runs the harness,
+   and **fails on a >10% regression in any Tier A `rows_per_s`** via
+   `tool/bench_compare.py` — which also seeds the baseline on first run
+   and skips (never fails) fixtures that exist on only one side, so adding
+   a fixture can't fail the night it lands.
+
+3. **The step-latency instrumentation** lives in the engine behind
+   `-DSEEML_STEP_TIMING` (set by `-DSEEML_BENCH=ON` / `SEEML_BENCH=1`):
+   the training stream's phase boundaries — after the last loss-forward
+   instruction, and at the first clip/optimizer instruction — are scanned
+   once at load, and each step's wall clock is split across them into
+   `UpdateEngine::step_timings()`. Default builds, and every emitted
+   package, compile the exact untouched dispatch loop; the split answers
+   Tier A's "where does the next kernel dollar go" (if bwd ≫ 2×fwd,
+   attention backward or GEMM-TN is the target).

--- a/runtime/engine/update_engine.cc
+++ b/runtime/engine/update_engine.cc
@@ -1,6 +1,9 @@
 #include "runtime/engine/update_engine.h"
 
 #include <bit>
+#ifdef SEEML_STEP_TIMING
+#include <chrono>
+#endif
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -237,6 +240,27 @@ std::expected<void, std::string> UpdateEngine::Initialize(const uint8_t* plan,
   train_program_ = std::move(train);
   merge_program_ = std::move(merge);
   eval_program_ = std::move(eval);
+#ifdef SEEML_STEP_TIMING
+  // Phase boundaries for the step-latency split (docs/benchmarks.md, Tier
+  // A): the forward pass ends after the LAST loss-forward instruction
+  // (kXEntPlusKL emits two, adjacent), and the optimizer phase starts at
+  // the FIRST clip/step instruction — everything between is the backward
+  // sweep. A missing family degrades to an empty range, never a bad split.
+  train_bwd_begin_ = train_program_.size();
+  train_opt_begin_ = train_program_.size();
+  for (size_t i = 0; i < train_program_.size(); ++i) {
+    const auto op = static_cast<up::OpCode>(train_program_[i].opcode);
+    if (op == up::OpCode::kSoftmaxXEntFwd || op == up::OpCode::kMseFwd ||
+        op == up::OpCode::kKLDistillFwd)
+      train_bwd_begin_ = i + 1;
+    if ((op == up::OpCode::kClipNorm || op == up::OpCode::kSgdStep ||
+         op == up::OpCode::kAdamWStep) &&
+        train_opt_begin_ == train_program_.size())
+      train_opt_begin_ = i;
+  }
+  if (train_opt_begin_ < train_bwd_begin_) train_opt_begin_ = train_bwd_begin_;
+  timings_ = {};
+#endif
   emit_table_ = std::move(emit);
   num_classes_ = num_classes;
   vocab_bound_ = vocab_bound;
@@ -252,7 +276,38 @@ std::expected<void, std::string> UpdateEngine::Initialize(const uint8_t* plan,
 }
 
 void UpdateEngine::Execute(const std::vector<up::UpdateInstruction>& program) {
-  for (const up::UpdateInstruction& ins : program) {
+  ExecuteRange(program, 0, program.size());
+}
+
+/// Executes the training stream, split at the phase boundaries scanned by
+/// Initialize, accumulating per-phase wall clock into timings_. Compiled to
+/// a plain Execute() unless the runtime is built with -DSEEML_STEP_TIMING
+/// (the benchmark-harness build), so the shipped runtime never reads a
+/// clock inside the step.
+void UpdateEngine::ExecuteTrainProgram() {
+#ifdef SEEML_STEP_TIMING
+  using clock = std::chrono::steady_clock;
+  const auto t0 = clock::now();
+  ExecuteRange(train_program_, 0, train_bwd_begin_);
+  const auto t1 = clock::now();
+  ExecuteRange(train_program_, train_bwd_begin_, train_opt_begin_);
+  const auto t2 = clock::now();
+  ExecuteRange(train_program_, train_opt_begin_, train_program_.size());
+  const auto t3 = clock::now();
+  ++timings_.steps;
+  timings_.fwd_seconds += std::chrono::duration<double>(t1 - t0).count();
+  timings_.bwd_seconds += std::chrono::duration<double>(t2 - t1).count();
+  timings_.opt_seconds += std::chrono::duration<double>(t3 - t2).count();
+#else
+  Execute(train_program_);
+#endif
+}
+
+void UpdateEngine::ExecuteRange(
+    const std::vector<up::UpdateInstruction>& program, size_t begin,
+    size_t end) {
+  for (size_t idx = begin; idx < end; ++idx) {
+    const up::UpdateInstruction& ins = program[idx];
     switch (static_cast<up::OpCode>(ins.opcode)) {
       case up::OpCode::kNop:
         break;
@@ -484,7 +539,7 @@ void UpdateEngine::ExecuteTrainOnce() {
   // adapter parameters, so deltas materialized by an earlier RunMerge are
   // stale and commit must re-merge first.
   merged_ = false;
-  Execute(train_program_);
+  ExecuteTrainProgram();
 }
 
 std::expected<void, std::string> UpdateEngine::ValidateDataset(
@@ -685,7 +740,7 @@ std::expected<TrainReport, std::string> UpdateEngine::TrainImpl(
       }
       step_ = s + 1;  // 1-indexed timestep for AdamW bias correction
       feeder.NextBatch(input_slot, label_slot);
-      Execute(train_program_);
+      ExecuteTrainProgram();
       ++executed;
 
       const float loss = LossValue();

--- a/runtime/engine/update_engine.h
+++ b/runtime/engine/update_engine.h
@@ -73,6 +73,21 @@ struct EvalMetrics {
   bool has_accuracy = false;
 };
 
+/// Accumulated wall-clock split of the training instruction stream, per
+/// phase: forward (stream start through the loss forward), backward, and
+/// clip + optimizer. Populated only when the runtime is built with
+/// -DSEEML_STEP_TIMING (the benchmark-harness build; see
+/// docs/benchmarks.md) — in every other build all fields stay zero and no
+/// clock is read inside the step, so the shipped runtime is untouched.
+/// The fields are unconditional so the header is identical under both
+/// builds (no ODR hazard between differently-configured objects).
+struct StepTimings {
+  uint64_t steps = 0;         // training-stream executions accumulated
+  double fwd_seconds = 0.0;
+  double bwd_seconds = 0.0;
+  double opt_seconds = 0.0;
+};
+
 struct TrainReport {
   uint64_t steps = 0;             // steps actually executed
   bool stopped_early = false;     // should_stop() interrupted the run
@@ -169,6 +184,11 @@ class UpdateEngine {
   /// I/O slots right now (no data feeding). Used for gradient verification.
   void ExecuteTrainOnce();
 
+  /// The step-latency accumulator (zeros unless built with
+  /// -DSEEML_STEP_TIMING; reset by every successful Load).
+  StepTimings step_timings() const { return timings_; }
+  void ResetStepTimings() { timings_ = {}; }
+
  private:
   /// Validates the candidate plan and commits engine state only if every
   /// contract passes: a rejected re-Load leaves the previous plan loaded
@@ -181,12 +201,22 @@ class UpdateEngine {
   [[nodiscard]] std::expected<void, std::string> ValidateDataset(
       Dataset& data) const;
   void Execute(const std::vector<seeml::update::UpdateInstruction>& program);
+  void ExecuteRange(const std::vector<seeml::update::UpdateInstruction>& program,
+                    size_t begin, size_t end);
+  /// Execute(train_program_), phase-timed under SEEML_STEP_TIMING.
+  void ExecuteTrainProgram();
 
   const float* ReadPtr(uint64_t ref) const;
   const int8_t* ReadPtrQ8(uint64_t ref) const;
   float* WritePtr(uint64_t ref);
 
   seeml::update::PlanHeader header_{};
+  // Step-latency instrumentation (SEEML_STEP_TIMING): phase boundaries of
+  // the training stream, scanned once at load; zeros/unused otherwise.
+  // Unconditional members keep the class layout build-independent.
+  StepTimings timings_{};
+  [[maybe_unused]] size_t train_bwd_begin_ = 0;  // first instr after loss fwd
+  [[maybe_unused]] size_t train_opt_begin_ = 0;  // first clip/optimizer instr
   std::vector<uint8_t> owned_plan_;       // file-loaded plans
   const uint8_t* plan_ = nullptr;         // borrowed or owned_plan_.data()
   size_t plan_size_ = 0;

--- a/test/support/builders.h
+++ b/test/support/builders.h
@@ -35,6 +35,13 @@ std::vector<float> RandnVector(size_t n, uint64_t seed, float stddev = 1.0f);
 update::SmfModel MakeMlp(int64_t in_dim, int64_t hidden, int64_t out_dim,
                          uint64_t seed);
 
+/// MakeMlp generalized to `layers` hidden Linear+ReLU layers of `hidden`
+/// width — the benchmark harness's feature-plan shapes:
+///   in -> [hidden (relu)] x layers -> out
+/// Layer i's tensors/ops carry the suffix i+1 (w1/b1/mm1/ab1/relu1, ...).
+update::SmfModel MakeMlpStack(int64_t in_dim, int64_t hidden, int64_t layers,
+                              int64_t out_dim, uint64_t seed);
+
 /// A two-layer net whose MatMuls share one square weight tensor "w"
 /// (weight tying):  x[?,dim] @ w -> relu -> @ w -> y.
 update::SmfModel MakeTiedMlp(int64_t dim, uint64_t seed);
@@ -56,6 +63,13 @@ update::SmfModel MakeGatedNet(int64_t in_dim, int64_t hidden, int64_t out_dim,
 ///   x2 = x1 + (silu(n2@wg) * (n2@wu))@wd; logits = rms_norm(x2, gf)@wh
 update::SmfModel MakeTinyDecoder(int64_t dim, int64_t heads, int64_t seq,
                                  int64_t ffn, int64_t vocab, uint64_t seed);
+
+/// MakeTinyDecoder generalized to `blocks` stacked pre-norm blocks (one
+/// shared final-norm + vocab head) — the benchmark harness's decoder
+/// shapes. Block i's tensors/ops carry the prefix "l<i>.".
+update::SmfModel MakeDecoderStack(int64_t dim, int64_t heads, int64_t seq,
+                                  int64_t ffn, int64_t vocab, int64_t blocks,
+                                  uint64_t seed);
 
 /// A one-block token-native decoder (SMF v4): rank-1 dynamic i32 input →
 /// Embedding[vocab, dim] → the pre-norm attention/SwiGLU block of

--- a/test/support/models.cc
+++ b/test/support/models.cc
@@ -135,6 +135,52 @@ SmfModel MakeGatedNet(int64_t in_dim, int64_t hidden, int64_t out_dim,
   return m;
 }
 
+SmfModel MakeMlpStack(int64_t in_dim, int64_t hidden, int64_t layers,
+                      int64_t out_dim, uint64_t seed) {
+  std::mt19937_64 rng(seed);
+  std::normal_distribution<float> dist(0.0f, 0.5f);
+  auto randv = [&](size_t n) {
+    std::vector<float> v(n);
+    for (auto& x : v) x = dist(rng);
+    return v;
+  };
+
+  SmfModel m;
+  m.input_name = "x";
+  m.output_name = "logits";
+  m.tensors.push_back({.name = "x", .dims = {-1, in_dim}, .is_const = false});
+  std::string prev = "x";
+  int64_t prev_dim = in_dim;
+  auto linear = [&](int idx, int64_t width, const std::string& out) {
+    const std::string w = "w" + std::to_string(idx);
+    const std::string b = "b" + std::to_string(idx);
+    m.tensors.push_back({.name = w,
+                         .dims = {prev_dim, width},
+                         .is_const = true,
+                         .data = AsBytes(randv(prev_dim * width))});
+    m.tensors.push_back({.name = b,
+                         .dims = {width},
+                         .is_const = true,
+                         .data = AsBytes(randv(width))});
+    m.ops.push_back({SmfOpKind::kMatMul, "mm" + std::to_string(idx),
+                     {prev, w}, "z" + std::to_string(idx)});
+    m.ops.push_back({SmfOpKind::kAddBias, "ab" + std::to_string(idx),
+                     {"z" + std::to_string(idx), b}, out});
+    prev = out;
+    prev_dim = width;
+  };
+  for (int i = 1; i <= layers; ++i) {
+    linear(i, hidden, "zb" + std::to_string(i));
+    m.ops.push_back({SmfOpKind::kRelu, "relu" + std::to_string(i),
+                     {"zb" + std::to_string(i)}, "h" + std::to_string(i)});
+    prev = "h" + std::to_string(i);
+  }
+  linear(static_cast<int>(layers) + 1, out_dim, "logits");
+  for (auto& t : m.tensors)
+    if (t.is_const) t.byte_size = t.data.size();
+  return m;
+}
+
 SmfModel MakeTinyDecoder(int64_t dim, int64_t heads, int64_t seq, int64_t ffn,
                          int64_t vocab, uint64_t seed) {
   std::mt19937_64 rng(seed);
@@ -191,6 +237,83 @@ SmfModel MakeTinyDecoder(int64_t dim, int64_t heads, int64_t seq, int64_t ffn,
   m.ops.push_back({SmfOpKind::kMatMul, "mmd", {"mg", "wd"}, "dn"});
   m.ops.push_back({SmfOpKind::kAdd, "res2", {"x1", "dn"}, "x2"});
   m.ops.push_back({SmfOpKind::kRmsNorm, "lnf", {"x2", "gf"}, "nf"});
+  m.ops.push_back({SmfOpKind::kMatMul, "mmh", {"nf", "wh"}, "logits"});
+  return m;
+}
+
+SmfModel MakeDecoderStack(int64_t dim, int64_t heads, int64_t seq,
+                          int64_t ffn, int64_t vocab, int64_t blocks,
+                          uint64_t seed) {
+  std::mt19937_64 rng(seed);
+  std::normal_distribution<float> dist(0.0f, 0.5f);
+  auto randv = [&](size_t n) {
+    std::vector<float> v(n);
+    for (auto& x : v) x = dist(rng);
+    return v;
+  };
+
+  SmfModel m;
+  m.input_name = "x";
+  m.output_name = "logits";
+  m.seq_len = static_cast<uint64_t>(seq);
+  m.tensors.push_back({.name = "x", .dims = {-1, dim}, .is_const = false});
+  auto add_const = [&](const std::string& name, std::vector<int64_t> dims,
+                       std::vector<float> data) {
+    m.tensors.push_back({.name = name,
+                         .dims = std::move(dims),
+                         .is_const = true,
+                         .data = AsBytes(data)});
+    m.tensors.back().byte_size = m.tensors.back().data.size();
+  };
+  auto gain = [&](int64_t n) {
+    std::vector<float> g(n, 1.0f);
+    for (auto& v : g) v += 0.1f * dist(rng);  // non-trivial gains
+    return g;
+  };
+
+  const auto h = static_cast<uint32_t>(heads);
+  std::string prev = "x";
+  for (int64_t i = 0; i < blocks; ++i) {
+    const std::string p = "l" + std::to_string(i) + ".";
+    add_const(p + "g1", {dim}, gain(dim));
+    add_const(p + "wq", {dim, dim}, randv(dim * dim));
+    add_const(p + "wk", {dim, dim}, randv(dim * dim));
+    add_const(p + "wv", {dim, dim}, randv(dim * dim));
+    add_const(p + "wo", {dim, dim}, randv(dim * dim));
+    add_const(p + "g2", {dim}, gain(dim));
+    add_const(p + "wg", {dim, ffn}, randv(dim * ffn));
+    add_const(p + "wu", {dim, ffn}, randv(dim * ffn));
+    add_const(p + "wd", {ffn, dim}, randv(ffn * dim));
+    m.ops.push_back({SmfOpKind::kRmsNorm, p + "ln1", {prev, p + "g1"},
+                     p + "n1"});
+    for (const char* w : {"q", "k", "v"})
+      m.ops.push_back({SmfOpKind::kMatMul, p + "mm" + w,
+                       {p + "n1", p + "w" + std::string(w)}, p + w});
+    m.ops.push_back({SmfOpKind::kRope, p + "ropeq", {p + "q"}, p + "qr", h});
+    m.ops.push_back({SmfOpKind::kRope, p + "ropek", {p + "k"}, p + "kr", h});
+    m.ops.push_back({SmfOpKind::kAttention, p + "attn",
+                     {p + "qr", p + "kr", p + "v"}, p + "a", h});
+    m.ops.push_back({SmfOpKind::kMatMul, p + "mmo", {p + "a", p + "wo"},
+                     p + "o"});
+    m.ops.push_back({SmfOpKind::kAdd, p + "res1", {prev, p + "o"}, p + "x1"});
+    m.ops.push_back({SmfOpKind::kRmsNorm, p + "ln2", {p + "x1", p + "g2"},
+                     p + "n2"});
+    m.ops.push_back({SmfOpKind::kMatMul, p + "mmg", {p + "n2", p + "wg"},
+                     p + "gt"});
+    m.ops.push_back({SmfOpKind::kMatMul, p + "mmu", {p + "n2", p + "wu"},
+                     p + "u"});
+    m.ops.push_back({SmfOpKind::kSilu, p + "silu", {p + "gt"}, p + "s"});
+    m.ops.push_back({SmfOpKind::kMul, p + "swiglu", {p + "s", p + "u"},
+                     p + "mg"});
+    m.ops.push_back({SmfOpKind::kMatMul, p + "mmd", {p + "mg", p + "wd"},
+                     p + "dn"});
+    m.ops.push_back({SmfOpKind::kAdd, p + "res2", {p + "x1", p + "dn"},
+                     p + "x2"});
+    prev = p + "x2";
+  }
+  add_const("gf", {dim}, gain(dim));
+  add_const("wh", {dim, vocab}, randv(dim * vocab));
+  m.ops.push_back({SmfOpKind::kRmsNorm, "lnf", {prev, "gf"}, "nf"});
   m.ops.push_back({SmfOpKind::kMatMul, "mmh", {"nf", "wh"}, "logits"});
   return m;
 }

--- a/tool/README.md
+++ b/tool/README.md
@@ -13,6 +13,8 @@ tool/
   export_model.py         PyTorch model + data  ->  SMF / SDS files
   seeml_update_compile.cc the compiler CLI       ->  a .seeu update package
   seeml_seeu_dump.cc      the plan disassembler   (inspect any .seeu)
+  seeml_bench.cc          the benchmark harness  ->  one JSON per run
+  bench_compare.py        the nightly Tier A regression gate over two runs
 ```
 
 ## What each one is for
@@ -37,6 +39,15 @@ than one that refuses to start.
 verifies the integrity seal and prints the header and instruction streams in
 human-readable form — the tool you reach for when a plan misbehaves and you
 need to see what the compiler actually emitted.
+
+**`seeml_bench.cc`** is the metric program of
+[docs/benchmarks.md](../docs/benchmarks.md) as a command: it compiles the
+standard seeded fixture set in-process, measures per-step latency by
+steps-regression at every requested thread width (with the engine's
+fwd/bwd/optimizer split when built with `-DSEEML_BENCH=ON` or
+`SEEML_BENCH=1 sh build/build.sh`), and emits one JSON per run.
+`bench_compare.py` diffs two such runs and fails on a >10% Tier A
+regression — the nightly `bench` job's gate.
 
 ## Where to go next
 

--- a/tool/bench_compare.py
+++ b/tool/bench_compare.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Gate a seeml-bench run against a stored baseline (stdlib only).
+
+Usage:
+    python3 bench_compare.py baseline.json current.json [--max-regression F]
+
+Compares the Tier A throughput metric — rows_per_s, per fixture per thread
+width — and exits 1 if any pair regressed by more than --max-regression
+(default 0.10, the >10% gate of docs/benchmarks.md). A missing baseline
+file exits 0 with a note: the first run of a new host seeds the baseline
+rather than failing it. Fixtures or thread widths present on only one side
+are reported and skipped — adding a fixture must not fail the night it
+lands. Everything is medians-of-medians upstream, so a >10% delta is
+signal, not noise.
+"""
+import argparse
+import json
+import os
+import sys
+
+
+def tier_a(report):
+    """{(fixture, threads): rows_per_s} from a seeml-bench JSON object."""
+    out = {}
+    for name, fx in report.get("fixtures", {}).items():
+        for t, m in fx.get("threads", {}).items():
+            out[(name, t)] = float(m["rows_per_s"])
+    return out
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("baseline")
+    p.add_argument("current")
+    p.add_argument("--max-regression", type=float, default=0.10,
+                   help="fractional Tier A loss that fails the gate (0.10)")
+    args = p.parse_args()
+
+    if not os.path.exists(args.baseline):
+        print(f"bench_compare: no baseline at {args.baseline} — "
+              "this run seeds it")
+        return 0
+    with open(args.baseline) as f:
+        base = tier_a(json.load(f))
+    with open(args.current) as f:
+        cur = tier_a(json.load(f))
+
+    failures, skipped = [], []
+    for key, base_v in sorted(base.items()):
+        if key not in cur:
+            skipped.append(f"{key[0]}@{key[1]}t: in baseline only")
+            continue
+        cur_v = cur[key]
+        delta = (cur_v - base_v) / base_v if base_v > 0 else 0.0
+        line = (f"{key[0]}@{key[1]}t: {base_v:.0f} -> {cur_v:.0f} rows/s "
+                f"({delta:+.1%})")
+        if delta < -args.max_regression:
+            failures.append(line)
+        else:
+            print(f"bench_compare: OK   {line}")
+    for key in sorted(cur.keys() - base.keys()):
+        skipped.append(f"{key[0]}@{key[1]}t: new, no baseline")
+    for s in skipped:
+        print(f"bench_compare: SKIP {s}")
+    for f_ in failures:
+        print(f"bench_compare: FAIL {f_}")
+    if failures:
+        print(f"bench_compare: {len(failures)} Tier A metric(s) regressed "
+              f"more than {args.max_regression:.0%}")
+        return 1
+    print("bench_compare: no Tier A regression")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tool/seeml_bench.cc
+++ b/tool/seeml_bench.cc
@@ -1,0 +1,359 @@
+// =============================================================================
+// seeml-bench — the benchmark harness of docs/benchmarks.md. Usage:
+//
+//   seeml-bench --out bench.json [--threads 1,8] [--steps-lo 20]
+//               [--steps-hi 80] [--repeats 3] [--fixtures name,name,...]
+//               [--version]
+//
+// Compiles the standard fixture set in-process (the seeded builders the
+// test suites share), trains each plan at every requested thread width, and
+// emits one JSON object per run — Tier A throughput (rows/s, per-step
+// latency by steps-regression: run two step counts, slope = per-step cost,
+// intercept = fixed lifecycle cost), the fwd/bwd/optimizer split from the
+// engine's SEEML_STEP_TIMING instrumentation (zeros unless the runtime was
+// built with it), per-step GEMM FLOPs read out of the compiled plan's own
+// instruction stream, and the Tier D lifecycle latencies (compile, load,
+// merge, checkpoint save).
+//
+// Everything is pinned: fixture seeds, dataset seeds, thread widths (via
+// SetParallelThreadCount, overriding SEEML_THREADS). Medians of --repeats
+// runs. Argument parsing is strict, as in seeml-update-compile: an unknown
+// flag, a missing value, or trailing garbage is a hard error (exit 2).
+// =============================================================================
+
+#include <algorithm>
+#include <chrono>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+#include <expected>
+#include <string>
+#include <vector>
+
+#include "compiler/diagnostics/logger.h"
+#include "compiler/driver/update_compiler.h"
+#include "runtime/engine/update_engine.h"
+#include "source/identity/version.h"
+#include "source/parallel/parallel_for.h"
+#include "source/plan/update_types.h"
+#include "test/support/builders.h"
+
+namespace {
+
+namespace up = seeml::update;
+namespace rt = seeml::update_rt;
+namespace tf = seeml::testing;
+using Clock = std::chrono::steady_clock;
+
+double MsSince(Clock::time_point t0) {
+  return std::chrono::duration<double, std::milli>(Clock::now() - t0).count();
+}
+
+double Median(std::vector<double> v) {
+  std::sort(v.begin(), v.end());
+  return v[v.size() / 2];
+}
+
+// --- The standard fixture set -----------------------------------------------
+// Shapes follow the issue-#56 baseline table; seeds are arbitrary but fixed
+// forever — changing one invalidates every stored baseline.
+
+struct Fixture {
+  const char* name;
+  const char* kind;  // "feature" | "decoder" | "token"
+  int64_t batch_rows;
+  int64_t seq;  // rows per sequence (1 for feature plans)
+  up::SmfModel (*model)();
+  std::expected<rt::Dataset, std::string> (*data)();
+};
+
+const Fixture kFixtures[] = {
+    {"mlp_64x512x3", "feature", 32, 1,
+     [] { return tf::MakeMlpStack(64, 512, 3, 4, 101); },
+     [] { return tf::MakeClassificationData(4096, 64, 102); }},
+    {"mlp_128x1024x2", "feature", 32, 1,
+     [] { return tf::MakeMlpStack(128, 1024, 2, 4, 103); },
+     [] { return tf::MakeClassificationData(4096, 128, 104); }},
+    {"dec_v256_d128_s32", "decoder", 128, 32,
+     [] { return tf::MakeDecoderStack(128, 8, 32, 512, 256, 4, 105); },
+     [] { return tf::MakeClassificationData(8192, 128, 106); }},
+    {"dec_v256_d128_s128", "decoder", 128, 128,
+     [] { return tf::MakeDecoderStack(128, 8, 128, 512, 256, 4, 107); },
+     [] { return tf::MakeClassificationData(8192, 128, 108); }},
+    {"dec_v512_d192_s32", "decoder", 128, 32,
+     [] { return tf::MakeDecoderStack(192, 8, 32, 768, 512, 4, 109); },
+     [] { return tf::MakeClassificationData(8192, 192, 110); }},
+    {"tok_v64_d64_s16", "token", 128, 16,
+     [] { return tf::MakeTinyTokenDecoder(64, 64, 4, 16, 256, 111); },
+     [] { return tf::MakeTokenCorpus(1024, 16, 64, 112); }},
+};
+
+/// Sums 2·M·N·K over every GEMM-family instruction in the plan's training
+/// stream — the plan itself is the ground truth for per-step matmul work.
+uint64_t GemmFlopsPerStep(const std::vector<uint8_t>& plan) {
+  up::PlanHeader h;
+  std::memcpy(&h, plan.data(), sizeof h);
+  const auto* ins = reinterpret_cast<const up::UpdateInstruction*>(
+      plan.data() + h.train_instr_offset);
+  uint64_t flops = 0;
+  for (uint64_t i = 0; i < h.train_instr_count; ++i) {
+    switch (static_cast<up::OpCode>(ins[i].opcode)) {
+      case up::OpCode::kGemmNN:
+      case up::OpCode::kGemmNT:
+      case up::OpCode::kGemmTN:
+      case up::OpCode::kGemmAccNN:
+      case up::OpCode::kGemmNNQ8:
+      case up::OpCode::kGemmNTQ8:
+        flops += 2 * ins[i].out[0] * ins[i].out[1] * ins[i].out[2];
+        break;
+      default:
+        break;
+    }
+  }
+  return flops;
+}
+
+// --- Strict argument cursor (the seeml-update-compile discipline) -----------
+
+struct Args {
+  std::vector<std::string> rest;
+  explicit Args(int argc, char** argv) {
+    for (int i = 1; i < argc; ++i) rest.emplace_back(argv[i]);
+  }
+  bool Take(const std::string& flag) {
+    auto it = std::find(rest.begin(), rest.end(), flag);
+    if (it == rest.end()) return false;
+    rest.erase(it);
+    return true;
+  }
+  std::expected<std::string, std::string> TakeValue(const std::string& flag,
+                                                    std::string def) {
+    auto it = std::find(rest.begin(), rest.end(), flag);
+    if (it == rest.end()) return def;
+    if (it + 1 == rest.end())
+      return std::unexpected(flag + " is missing its value");
+    std::string v = *(it + 1);
+    rest.erase(it, it + 2);
+    return v;
+  }
+};
+
+std::expected<uint64_t, std::string> ParseU64(const std::string& flag,
+                                              const std::string& v) {
+  if (v.empty()) return std::unexpected(flag + " must be a positive integer");
+  uint64_t out = 0;
+  for (char c : v) {
+    if (c < '0' || c > '9')
+      return std::unexpected(flag + ": '" + v + "' is not a whole number");
+    out = out * 10 + static_cast<uint64_t>(c - '0');
+  }
+  if (out == 0) return std::unexpected(flag + " must be >= 1");
+  return out;
+}
+
+std::expected<std::vector<std::string>, std::string> SplitCsv(
+    const std::string& flag, const std::string& v) {
+  std::vector<std::string> out;
+  size_t start = 0;
+  while (start <= v.size()) {
+    size_t comma = v.find(',', start);
+    if (comma == std::string::npos) comma = v.size();
+    if (comma == start)
+      return std::unexpected(flag + ": empty element in '" + v + "'");
+    out.push_back(v.substr(start, comma - start));
+    start = comma + 1;
+  }
+  return out;
+}
+
+int Fail(const std::string& msg) {
+  std::fprintf(stderr, "seeml-bench: %s\n", msg.c_str());
+  return 2;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  // Six in-process compiles would otherwise narrate every pass at INFO;
+  // the harness's own stderr lines are the progress report.
+  seeml::diag::Logger::SetLevel(seeml::diag::LogLevel::kWarn);
+  Args args(argc, argv);
+  if (args.Take("--version")) {
+    std::printf("seeml-bench %s\n", seeml::update::kSeemlVersion);
+    return 0;
+  }
+
+  auto out_path = args.TakeValue("--out", "");
+  auto threads_csv = args.TakeValue("--threads", "1,8");
+  auto lo_s = args.TakeValue("--steps-lo", "20");
+  auto hi_s = args.TakeValue("--steps-hi", "80");
+  auto repeats_s = args.TakeValue("--repeats", "3");
+  auto fixtures_csv = args.TakeValue("--fixtures", "");
+  for (auto* v : {&out_path, &threads_csv, &lo_s, &hi_s, &repeats_s,
+                  &fixtures_csv})
+    if (!*v) return Fail(v->error());
+  if (!args.rest.empty()) return Fail("unknown argument '" + args.rest[0] +
+                                      "'");
+  if (out_path->empty())
+    return Fail("--out is required\nusage: seeml-bench --out bench.json "
+                "[--threads 1,8] [--steps-lo 20] [--steps-hi 80] "
+                "[--repeats 3] [--fixtures name,...] [--version]");
+
+  auto lo = ParseU64("--steps-lo", *lo_s);
+  auto hi = ParseU64("--steps-hi", *hi_s);
+  auto repeats = ParseU64("--repeats", *repeats_s);
+  for (auto* v : {&lo, &hi, &repeats})
+    if (!*v) return Fail(v->error());
+  if (*hi <= *lo) return Fail("--steps-hi must exceed --steps-lo");
+
+  auto thread_names = SplitCsv("--threads", *threads_csv);
+  if (!thread_names) return Fail(thread_names.error());
+  std::vector<uint64_t> threads;
+  for (const auto& t : *thread_names) {
+    auto n = ParseU64("--threads", t);
+    if (!n) return Fail(n.error());
+    threads.push_back(*n);
+  }
+
+  std::vector<const Fixture*> selected;
+  if (fixtures_csv->empty()) {
+    for (const Fixture& f : kFixtures) selected.push_back(&f);
+  } else {
+    auto names = SplitCsv("--fixtures", *fixtures_csv);
+    if (!names) return Fail(names.error());
+    for (const auto& n : *names) {
+      const Fixture* found = nullptr;
+      for (const Fixture& f : kFixtures)
+        if (n == f.name) found = &f;
+      if (!found) return Fail("--fixtures: unknown fixture '" + n + "'");
+      selected.push_back(found);
+    }
+  }
+
+  FILE* out = std::fopen(out_path->c_str(), "w");
+  if (!out) return Fail("cannot open '" + *out_path + "' for writing");
+  std::fprintf(out,
+               "{\n  \"seeml_version\": \"%s\",\n  \"schema\": 1,\n"
+               "  \"config\": {\"steps_lo\": %" PRIu64 ", \"steps_hi\": %"
+               PRIu64 ", \"repeats\": %" PRIu64 ", \"threads\": \"%s\"},\n"
+               "  \"fixtures\": {",
+               seeml::update::kSeemlVersion, *lo, *hi, *repeats,
+               threads_csv->c_str());
+
+  bool first_fixture = true;
+  for (const Fixture* f : selected) {
+    std::fprintf(stderr, "seeml-bench: %s\n", f->name);
+    const up::SmfModel model = f->model();
+    up::UpdateConfig config = tf::BaseConfig(f->batch_rows);
+    config.lora.rank = 8;
+    config.lora.alpha = 16.0f;
+
+    const auto t_compile = Clock::now();
+    auto compiled = up::UpdateCompiler(config).Compile(model);
+    if (!compiled) return Fail(f->name + (": " + compiled.error()));
+    const double compile_ms = MsSince(t_compile);
+
+    rt::UpdateEngine engine;
+    const auto t_load = Clock::now();
+    if (auto ok = engine.LoadFromMemory(compiled->plan.data(),
+                                        compiled->plan.size());
+        !ok)
+      return Fail(f->name + (": " + ok.error()));
+    const double load_ms = MsSince(t_load);
+
+    auto data = f->data();
+    if (!data) return Fail(f->name + (": " + data.error()));
+
+    rt::TrainOptions quiet;
+    quiet.log_every = 0;
+
+    std::fprintf(out,
+                 "%s\n    \"%s\": {\n"
+                 "      \"kind\": \"%s\", \"batch_rows\": %" PRId64
+                 ", \"seq\": %" PRId64 ",\n"
+                 "      \"plan_bytes\": %zu, \"arena_bytes\": %" PRIu64
+                 ", \"persistent_bytes\": %" PRIu64 ", \"rodata_bytes\": %"
+                 PRIu64 ",\n"
+                 "      \"train_instructions\": %" PRIu64
+                 ", \"gemm_flops_per_step\": %" PRIu64 ",\n"
+                 "      \"compile_ms\": %.2f, \"load_ms\": %.3f,\n"
+                 "      \"threads\": {",
+                 first_fixture ? "" : ",", f->name, f->kind, f->batch_rows,
+                 f->seq, compiled->plan.size(), compiled->arena_size,
+                 compiled->persistent_size, compiled->rodata_size,
+                 compiled->train_instruction_count,
+                 GemmFlopsPerStep(compiled->plan), compile_ms, load_ms);
+    first_fixture = false;
+
+    bool first_thread = true;
+    for (uint64_t t : threads) {
+      up::SetParallelThreadCount(t);
+      // Warm the pool, the caches, and the feeder before timing.
+      if (auto r = engine.Train(*data, 4, quiet); !r)
+        return Fail(f->name + (": " + r.error()));
+
+      std::vector<double> per_step_ms, lifecycle_ms;
+      engine.ResetStepTimings();
+      for (uint64_t rep = 0; rep < *repeats; ++rep) {
+        const auto t_lo = Clock::now();
+        if (auto r = engine.Train(*data, *lo, quiet); !r)
+          return Fail(f->name + (": " + r.error()));
+        const double wall_lo = MsSince(t_lo);
+        const auto t_hi = Clock::now();
+        if (auto r = engine.Train(*data, *hi, quiet); !r)
+          return Fail(f->name + (": " + r.error()));
+        const double wall_hi = MsSince(t_hi);
+        const double slope = (wall_hi - wall_lo) /
+                             static_cast<double>(*hi - *lo);
+        per_step_ms.push_back(slope);
+        lifecycle_ms.push_back(wall_lo - slope * static_cast<double>(*lo));
+      }
+      const double step_ms = Median(per_step_ms);
+      const double rows_per_s =
+          step_ms > 0.0 ? 1000.0 * static_cast<double>(f->batch_rows) /
+                              step_ms
+                        : 0.0;
+      const double gflops =
+          step_ms > 0.0
+              ? static_cast<double>(GemmFlopsPerStep(compiled->plan)) /
+                    (step_ms * 1e6)
+              : 0.0;
+      const rt::StepTimings st = engine.step_timings();
+      const double denom = st.steps ? static_cast<double>(st.steps) : 1.0;
+      std::fprintf(out,
+                   "%s\n        \"%" PRIu64 "\": {\"step_ms\": %.3f, "
+                   "\"lifecycle_ms\": %.2f, \"rows_per_s\": %.0f, "
+                   "\"gemm_gflops\": %.1f, \"fwd_ms\": %.3f, "
+                   "\"bwd_ms\": %.3f, \"opt_ms\": %.3f}",
+                   first_thread ? "" : ",", t, step_ms,
+                   Median(lifecycle_ms), rows_per_s, gflops,
+                   1000.0 * st.fwd_seconds / denom,
+                   1000.0 * st.bwd_seconds / denom,
+                   1000.0 * st.opt_seconds / denom);
+      first_thread = false;
+    }
+
+    const auto t_merge = Clock::now();
+    if (auto ok = engine.RunMerge(); !ok)
+      return Fail(f->name + (": " + ok.error()));
+    const double merge_ms = MsSince(t_merge);
+    const std::string ckpt = *out_path + "." + f->name + ".ckpt.tmp";
+    const auto t_ckpt = Clock::now();
+    if (auto ok = engine.SaveCheckpoint(ckpt); !ok)
+      return Fail(f->name + (": " + ok.error()));
+    const double ckpt_ms = MsSince(t_ckpt);
+    std::remove(ckpt.c_str());
+    std::fprintf(out,
+                 "\n      },\n      \"merge_ms\": %.3f, "
+                 "\"checkpoint_save_ms\": %.3f\n    }",
+                 merge_ms, ckpt_ms);
+  }
+
+  std::fprintf(out, "\n  }\n}\n");
+  // A truncated report must not exit 0 — same discipline as --report in
+  // seeml-update-compile.
+  if (std::ferror(out) || std::fclose(out) != 0)
+    return Fail("failed writing '" + *out_path + "'");
+  std::fprintf(stderr, "seeml-bench: wrote %s\n", out_path->c_str());
+  return 0;
+}


### PR DESCRIPTION
Closes #56.

Lands all three "what to build next" items of `docs/benchmarks.md`. Every performance claim so far has required external wall-clock measurement; this makes the metric program a command.

## 1. `tool/seeml_bench.cc`

Compiles the **standard fixture set in-process** — the shared seeded builders, extended with two generalized fixtures (`MakeMlpStack`, `MakeDecoderStack`) so the issue's baseline shapes exist: two MLP stacks, three 4-block decoders, one token-native decoder. Per fixture, per thread width (`SetParallelThreadCount`, pinned):

- **Steps-regression**, as prescribed in the issue: train `--steps-lo` then `--steps-hi`; slope = per-step latency, intercept = fixed lifecycle cost. Medians of `--repeats` (3), seeds pinned.
- Tier A `rows_per_s` and effective **GEMM GFLOP/s summed from the plan's own instruction stream** (2·M·N·K over every GEMM-family instruction — no analytic guessing).
- The **fwd/bwd/optimizer split** from the new engine instrumentation.
- Tier D lifecycle: compile, load+validate, merge, checkpoint-save ms, plan/arena/rodata bytes.

Strict CLI in the `seeml-update-compile` mold — unknown flag, bad value, unknown fixture, `--steps-hi <= --steps-lo` are one-line errors with exit 2; the JSON writer checks `ferror`+`fclose` so a truncated report cannot exit 0.

## 2. Nightly `bench` CI job + `tool/bench_compare.py`

Restores the previous night's numbers via `actions/cache` restore-key chaining (the fuzz-corpus trust model), runs the harness at `--threads 1,2,4`, and **fails on a >10% regression in any Tier A `rows_per_s`**. The stdlib-only compare script seeds a missing baseline (first night passes) and skips — never fails — fixtures present on only one side, so adding a fixture can't fail the night it lands. Run JSON uploaded as an artifact every night.

## 3. Step-latency instrumentation

`Execute()` → `ExecuteRange()`; at load the training stream's phase boundaries are scanned once (forward ends after the **last loss-forward** instruction — xent+kl emits two; optimizer starts at the **first clip/step** instruction), and each step's wall clock is split across them into `UpdateEngine::step_timings()`. Compiled in only under `SEEML_STEP_TIMING`, set by `-DSEEML_BENCH=ON` (CMake) or `SEEML_BENCH=1 sh build/build.sh` — default builds and every emitted package keep the byte-identical dispatch loop, and the header has no conditional members (no ODR hazard between differently-configured objects).

## Verification

- 25/25 suites pass on **both** the instrumented and the default build; the default build produces no bench binary and an untouched runtime.
- A full run (6 fixtures × 4 thread widths, 232 s on Apple M4) **reproduces the 2026-08-13 bespoke baselines** where shapes overlap: mlp 64→[512]×3 at 9.76/2.23 ms per step (1/8 threads) vs the issue table's 10.7/2.4, scaling 4.4× vs 4.4×.
- First insight from the split: **bwd = 2.1–2.8× fwd on every fixture, optimizer ≈ 0** — the "where the next kernel dollar goes" signal the G1b Metal go/no-go needs.
- `bench_compare.py` verified three ways (pass / >10% fail exit 1 / missing-baseline seed); `nightly.yml` YAML-validated.

| Fixture | 1 thr | 8 thr | scaling | rows/s @8T | GF/s |
|---|---|---|---|---|---|
| mlp_64x512x3 | 9.76 ms | 2.23 ms | 4.4× | 14,339 | 33.3 |
| mlp_128x1024x2 | 20.1 ms | 3.63 ms | 5.5× | 8,823 | 41.2 |
| dec_v256_d128_s32 | 74.9 ms | 18.4 ms | 4.1× | 6,944 | 33.4 |
| dec_v256_d128_s128 | 82.7 ms | 19.9 ms | 4.2× | 6,436 | 30.9 |
| dec_v512_d192_s32 | 171.6 ms | 31.5 ms | 5.5× | 4,068 | 42.6 |
| tok_v64_d64_s16 | 4.43 ms | 2.49 ms | 1.8× | 51,495 | 16.9 |