### PR TITLE
v1.2.4 field-report fixes: SMF v5 RoPE base, fail-closed bench gate, P3 sweep, GPU roadmap

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -129,6 +129,15 @@ jobs:
           path: bench-baseline
           key: bench-baseline-${{ github.run_id }}
           restore-keys: bench-baseline-
+      # The pinned epoch: a fixed cache key is saved once and never
+      # overwritten, so the gate also diffs against a reference that does
+      # not roll forward (a <10%/night drift cannot compound past it).
+      # Bump the key suffix to start a new epoch deliberately.
+      - name: Restore epoch baseline
+        uses: actions/cache@v4
+        with:
+          path: bench-epoch
+          key: bench-epoch-v1
       - name: Configure
         run: >
           cmake -S . -B build-bench
@@ -139,9 +148,16 @@ jobs:
       - name: Bench
         run: ./build-bench/seeml-bench --out bench.json --threads 1,2,4
       - name: Gate against baseline
-        run: python3 tool/bench_compare.py bench-baseline/bench.json bench.json
+        run: >
+          python3 tool/bench_compare.py bench-baseline/bench.json bench.json
+          --epoch-baseline bench-epoch/bench.json
       - name: Store as next baseline
         run: mkdir -p bench-baseline && cp bench.json bench-baseline/bench.json
+      - name: Seed the epoch baseline (first night only)
+        run: |
+          if [ ! -f bench-epoch/bench.json ]; then
+            mkdir -p bench-epoch && cp bench.json bench-epoch/bench.json
+          fi
       - name: Upload run
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,14 @@ on:
   schedule:
     - cron: "17 7 * * *"
   workflow_dispatch:
+    inputs:
+      reseed_baseline:
+        description: >-
+          Skip the Tier A gate and store this run as the new rolling
+          baseline (after a fixture/metric rename the fail-closed gate
+          would otherwise stay red; the epoch baseline is left alone).
+        type: boolean
+        default: false
 
 jobs:
   tsan:
@@ -148,12 +156,18 @@ jobs:
       - name: Bench
         run: ./build-bench/seeml-bench --out bench.json --threads 1,2,4
       - name: Gate against baseline
+        if: ${{ !inputs.reseed_baseline }}
         run: >
           python3 tool/bench_compare.py bench-baseline/bench.json bench.json
           --epoch-baseline bench-epoch/bench.json
       - name: Store as next baseline
         run: mkdir -p bench-baseline && cp bench.json bench-baseline/bench.json
-      - name: Seed the epoch baseline (first night only)
+      # Seeded from the first GREEN night (actions/cache saves only when the
+      # job succeeds, and the seed step does not run after a failed gate),
+      # so the drift reference is never a run that already regressed. A
+      # reseed run never touches it; bump the key suffix to start an epoch.
+      - name: Seed the epoch baseline (first green night only)
+        if: ${{ !inputs.reseed_baseline }}
         run: |
           if [ ! -f bench-epoch/bench.json ]; then
             mkdir -p bench-epoch && cp bench.json bench-epoch/bench.json

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ What SeeML can train today, stated up front:
   operator kinds: `MatMul`, `AddBias`, `Relu`, `Gelu`, `Silu`, `Mul`,
   `LayerNorm` (SMF v2), `Add`, `RmsNorm`, `Rope`, and causal `Attention`
   (SMF v3, with model-level sequence geometry), plus `Embedding` (SMF v4)
+  and a per-op RoPE base θ (SMF v5)
   — token-native decoders train end to end: the corpus carries i32 token
   ids (SDS v2), next-token labels are derived from the shifted view, and
   the frozen embedding gathers on-device. The PyTorch exporter accepts an

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -263,7 +263,11 @@ dispatch path: synchronous copy-in/copy-out GEMM via shared-mode
 compiler-emitted source string. Contracts: bitwise-reproducible on the same
 device, but *not* bitwise-equal to CPU kernels (different FMA contraction) —
 cross-backend comparison is tolerance-based. The training engine does not yet
-dispatch to it, and the file is excluded from vendored packages.
+dispatch to it, and the file is excluded from vendored packages. The path from
+harness to backend — engine backend switch, zero-copy residency, batched
+encoding, `simdgroup_matrix` kernels, package vendoring — is scoped as
+milestone v1.3.0 in `docs/roadmap.md` (Project 5; GitHub epic #59), with the
+CPU kept as the bitwise-deterministic reference backend.
 
 ---
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -239,7 +239,7 @@ raise the oldest-readable floor; newer-than-reader is always rejected):
 
 | Format | Magic | Current version | Implemented in |
 |---|---|---|---|
-| SMF (model container) | `"SMF1"` | v4 (readers accept v1–v4) | `source/language/model_format.*`, `compiler/frontend/ingressor/model_{reader,writer}.cc`, Python writer in `tool/export_model.py` |
+| SMF (model container) | `"SMF1"` | v5 (readers accept v1–v5; writers emit the lowest version the model needs) | `source/language/model_format.*`, `compiler/frontend/ingressor/model_{reader,writer}.cc`, Python writer in `tool/export_model.py` |
 | SDS (dataset) | `"SDS1"` | v1 (feature rows) / v2 (token records) | `runtime/feeder/dataset.cc`, Python writer |
 | SEEU (update plan) | `"SEEU"` | v7, oldest-readable v4 | written by `compiler/backend/trainer/*` + driver; read/validated by `runtime/validator` + `runtime/engine`; disassembled by `seeml-seeu-dump` |
 | SEKP (checkpoint) | `"SEKP"` | v3 | `runtime/custodian/checkpoint.cc` |

--- a/build/build.sh
+++ b/build/build.sh
@@ -5,9 +5,17 @@ set -e
 cd "$(dirname "$0")/.."
 CXX="${CXX:-c++}"
 FLAGS="-std=c++23 -O2 -Wall -Wextra -Werror -pthread -I. -DSEEML_SOURCE_DIR='\"$(pwd)\"'"
-# SEEML_BENCH=1 (any value but empty or 0) mirrors CMake's -DSEEML_BENCH=ON: compiles the runtime with
+# SEEML_BENCH=1 mirrors CMake's -DSEEML_BENCH=ON; empty, 0, off, false and
+# no (any case) are OFF, mirroring CMake's own falsy spellings.
+seeml_bench_enabled() {
+  case "$(printf '%s' "${SEEML_BENCH:-}" | tr '[:upper:]' '[:lower:]')" in
+    ""|0|off|false|no|n) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+# SEEML_BENCH=1 mirrors CMake's -DSEEML_BENCH=ON: compiles the runtime with
 # the per-phase step clock and links the seeml-bench harness at the end.
-if [ -n "${SEEML_BENCH:-}" ] && [ "${SEEML_BENCH}" != 0 ]; then
+if seeml_bench_enabled; then
   FLAGS="$FLAGS -DSEEML_STEP_TIMING"
 fi
 
@@ -117,7 +125,7 @@ echo "  LINK seeml-seeu-dump"
 # PlanSelfHash (the v4 integrity seal) runs on the parallel substrate.
 eval "$CXX -pthread build/seeml_seeu_dump.o build/parallel_for.o -o build/seeml-seeu-dump"
 
-if [ -n "${SEEML_BENCH:-}" ] && [ "${SEEML_BENCH}" != 0 ]; then
+if seeml_bench_enabled; then
   echo "  CXX+LINK seeml-bench"
   eval "$CXX $FLAGS -c tool/seeml_bench.cc -o build/seeml_bench.o"
   eval "$CXX -pthread build/seeml_bench.o build/fixtures_models.o \

--- a/build/build.sh
+++ b/build/build.sh
@@ -5,9 +5,9 @@ set -e
 cd "$(dirname "$0")/.."
 CXX="${CXX:-c++}"
 FLAGS="-std=c++23 -O2 -Wall -Wextra -Werror -pthread -I. -DSEEML_SOURCE_DIR='\"$(pwd)\"'"
-# SEEML_BENCH=1 mirrors CMake's -DSEEML_BENCH=ON: compiles the runtime with
+# SEEML_BENCH=1 (any value but empty or 0) mirrors CMake's -DSEEML_BENCH=ON: compiles the runtime with
 # the per-phase step clock and links the seeml-bench harness at the end.
-if [ -n "${SEEML_BENCH:-}" ]; then
+if [ -n "${SEEML_BENCH:-}" ] && [ "${SEEML_BENCH}" != 0 ]; then
   FLAGS="$FLAGS -DSEEML_STEP_TIMING"
 fi
 
@@ -117,7 +117,7 @@ echo "  LINK seeml-seeu-dump"
 # PlanSelfHash (the v4 integrity seal) runs on the parallel substrate.
 eval "$CXX -pthread build/seeml_seeu_dump.o build/parallel_for.o -o build/seeml-seeu-dump"
 
-if [ -n "${SEEML_BENCH:-}" ]; then
+if [ -n "${SEEML_BENCH:-}" ] && [ "${SEEML_BENCH}" != 0 ]; then
   echo "  CXX+LINK seeml-bench"
   eval "$CXX $FLAGS -c tool/seeml_bench.cc -o build/seeml_bench.o"
   eval "$CXX -pthread build/seeml_bench.o build/fixtures_models.o \

--- a/compiler/backend/trainer/instruction_lowering.cc
+++ b/compiler/backend/trainer/instruction_lowering.cc
@@ -1,4 +1,5 @@
 #include "compiler/backend/trainer/instruction_lowering.h"
+#include "source/language/model_format.h"
 
 #include <bit>
 
@@ -221,7 +222,10 @@ std::expected<std::vector<UpdateInstruction>, std::string> LowerOps(
         ins.in[1] = ref(op->result(0));
         ins.out[0] = bs;
         ins.out[1] = hd;
-        ins.out[2] = F32Bits(op->getAttrAs<float>("base").value_or(10000.0f));
+        // The parser always sets "base" (SMF v5 attr1, or the format
+        // default); the fallback only covers SIR built by hand in tests.
+        ins.out[2] = F32Bits(
+            op->getAttrAs<float>("base").value_or(kSmfDefaultRopeBase));
       } else if (m == "sc_high.attention") {
         set(OpCode::kAttnFwd);
         ins.in[0] = ref(op->operand(0));   // q

--- a/compiler/frontend/ingressor/model_reader.cc
+++ b/compiler/frontend/ingressor/model_reader.cc
@@ -194,6 +194,13 @@ std::expected<SmfModel, std::string> LoadSmf(const std::string& path) {
     op.output = r.ReadStr();
     if (version >= 3) op.attr0 = r.Read<uint32_t>();
     if (version >= 5) op.attr1 = r.Read<uint32_t>();
+    // attr1 is defined only for kRope (the rotary base); on every other
+    // kind it is reserved and must be zero, so a future meaning can never
+    // be silently misread by a reader that predates it.
+    if (op.attr1 != 0 && op.kind != SmfOpKind::kRope)
+      return tokenizing::Error("op '" + op.name + "' carries a nonzero attr1, "
+                               "which its kind does not define, in '" + path +
+                               "'");
     model.ops.push_back(std::move(op));
   }
 

--- a/compiler/frontend/ingressor/model_reader.cc
+++ b/compiler/frontend/ingressor/model_reader.cc
@@ -193,6 +193,7 @@ std::expected<SmfModel, std::string> LoadSmf(const std::string& path) {
     for (uint8_t k = 0; k < n_in; ++k) op.inputs.push_back(r.ReadStr());
     op.output = r.ReadStr();
     if (version >= 3) op.attr0 = r.Read<uint32_t>();
+    if (version >= 5) op.attr1 = r.Read<uint32_t>();
     model.ops.push_back(std::move(op));
   }
 

--- a/compiler/frontend/ingressor/model_writer.cc
+++ b/compiler/frontend/ingressor/model_writer.cc
@@ -93,6 +93,7 @@ std::expected<void, std::string> SaveSmf(const std::string& path,
       for (const auto& in : op.inputs) w.WriteStr(in);
       w.WriteStr(op.output);
       w.Write<uint32_t>(op.attr0);
+      w.Write<uint32_t>(op.attr1);
     }
   };
 

--- a/compiler/frontend/parser/parser.cc
+++ b/compiler/frontend/parser/parser.cc
@@ -162,11 +162,16 @@ std::expected<sir::Value*, std::string> BuildForward(
           return parsing::OpError("Rope", op.name, "needs 1 input");
         auto x = resolver.Resolve(op.inputs[0]);
         if (!x) return std::unexpected(x.error());
-        if (auto ok = sema::CheckRope(op, **x, op.attr0, model.seq_len); !ok)
+        if (auto ok = sema::CheckRope(op, **x, op.attr0, model.seq_len,
+                                      op.attr1);
+            !ok)
           return std::unexpected(ok.error());
         sir::Operation* r = block.appendOp("sc_high.rope");
         r->setAttribute("heads", static_cast<int64_t>(op.attr0));
         r->setAttribute("seq", static_cast<int64_t>(model.seq_len));
+        // v5 attr1: the rotary base, lowered into kRopeFwd's out[2] and
+        // copied onto the backward by autodiff. Pre-v5 files mean 10000.
+        r->setAttribute("base", sema::RopeBaseOf(op.attr1));
         r->addOperand(*x);
         resolver.Bind(op.output,
                       r->addResult(prefix + op.output, sir::DataType::F32,
@@ -232,6 +237,14 @@ std::expected<sir::Value*, std::string> BuildForward(
                       sir::Shape{rows});
         break;
       }
+      default:
+        // The reader bounds kinds per file version, so this is unreachable
+        // from a loaded file; an in-memory model with a kind this parser
+        // does not know must still get a diagnostic naming the op, not a
+        // silently unbound output blamed on "never produced".
+        return parsing::OpError("Op", op.name,
+                                "unsupported op kind " +
+                                    std::to_string(static_cast<int>(op.kind)));
     }
   }
 

--- a/compiler/frontend/parser/sema.cc
+++ b/compiler/frontend/parser/sema.cc
@@ -1,5 +1,7 @@
 #include "compiler/frontend/parser/sema.h"
 
+#include <bit>
+#include <cmath>
 #include <string_view>
 #include <unordered_set>
 
@@ -243,9 +245,25 @@ std::expected<void, std::string> CheckSeqGeometry(const char* unit,
 
 }  // namespace
 
+float RopeBaseOf(uint32_t base_bits) {
+  return base_bits == 0 ? kSmfDefaultRopeBase : std::bit_cast<float>(base_bits);
+}
+
 std::expected<void, std::string> CheckRope(const SmfOp& op, const sir::Value& x,
-                                           uint32_t heads, uint64_t seq_len) {
-  return CheckSeqGeometry("Rope", op, x, heads, seq_len, /*even_head=*/true);
+                                           uint32_t heads, uint64_t seq_len,
+                                           uint32_t base_bits) {
+  if (auto ok = CheckSeqGeometry("Rope", op, x, heads, seq_len,
+                                 /*even_head=*/true);
+      !ok)
+    return ok;
+  // The base feeds pow(base, -2i/d): anything non-finite, non-positive, or
+  // <= 1 makes the rotation angles degenerate (or NaN) rather than a
+  // different positional encoding.
+  const float base = RopeBaseOf(base_bits);
+  if (!std::isfinite(base) || base <= 1.0f)
+    return parsing::OpError("Rope", op.name,
+                            "rotary base (attr1) must be a finite float > 1");
+  return {};
 }
 
 std::expected<void, std::string> CheckEmbedding(const SmfOp& op,

--- a/compiler/frontend/parser/sema.h
+++ b/compiler/frontend/parser/sema.h
@@ -60,10 +60,14 @@ namespace seeml::update::sema {
     const seeml::sir::Value& gamma);
 
 /// RoPE: rank-2 input; heads (attr0) divides the width into an even head
-/// width; the model declares a seq_len that divides the row count.
+/// width; the model declares a seq_len that divides the row count; the
+/// rotary base (attr1 as f32 bits, 0 = default) is finite and > 1.
 [[nodiscard]] std::expected<void, std::string> CheckRope(
     const SmfOp& op, const seeml::sir::Value& x, uint32_t heads,
-    uint64_t seq_len);
+    uint64_t seq_len, uint32_t base_bits);
+
+/// The rotary base a kRope op's attr1 encodes (kSmfDefaultRopeBase for 0).
+float RopeBaseOf(uint32_t base_bits);
 
 /// Embedding: tokens are the rank-1 i32 graph input; table is rank-2.
 [[nodiscard]] std::expected<void, std::string> CheckEmbedding(

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -66,7 +66,7 @@ keeps numbers comparable across commits.
 |---|---|---|
 | **CI wall time per job** | each ci.yml job's duration trend | the per-diff feedback loop; when build-and-test crosses ~10 min, precompiled-header or unity-build work pays |
 | **full local build time** | `build/build.sh` clean | same loop locally; the single biggest dev-speed lever in a -O2 -Werror tree |
-| **suite runtime top-10** | slowest tests trend | keeps the 251-test suite honest — one 60 s test taxes every diff forever |
+| **suite runtime top-10** | slowest tests trend | keeps the 345-test suite honest — one 60 s test taxes every diff forever |
 | **fuzz corpus coverage** | edges covered nightly (libFuzzer `-print_final_stats`) | whether the fourth arm (compile-of-SMF) is still finding new ground or needs structure-aware mutators |
 
 ## Reference points from this branch (not benchmarks — sanity anchors)
@@ -109,7 +109,12 @@ All three pieces of this program exist:
    and **fails on a >10% regression in any Tier A `rows_per_s`** via
    `tool/bench_compare.py` — which also seeds the baseline on first run
    and skips (never fails) fixtures that exist on only one side, so adding
-   a fixture can't fail the night it lands.
+   a fixture can't fail the night it lands. Two fail-closed rules keep the
+   gate honest: a comparison with **zero overlapping keys is an error**
+   (a renamed metric must re-seed deliberately, not pass silently), and a
+   **pinned epoch baseline** (`--epoch-baseline`, cache key `bench-epoch-v1`,
+   saved once and never rolled forward) is diffed at a 15% threshold so a
+   sub-10%/night drift cannot compound unnoticed.
 
 3. **The step-latency instrumentation** lives in the engine behind
    `-DSEEML_STEP_TIMING` (set by `-DSEEML_BENCH=ON` / `SEEML_BENCH=1`):

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -38,7 +38,7 @@ The dependency-free model container consumed by `seeml-update-compile` (source a
 
 ```
 u32 magic  "SMF1" (0x31464D53)
-u32 version         1..4 accepted; writer emits 4
+u32 version         1..5 accepted; writer emits 5
 u32 num_tensors
 u32 num_ops
 str input_name      (str = u16 length + bytes, no terminator)
@@ -61,7 +61,8 @@ ops[num_ops] (topologically ordered):
   u8   num_inputs
   str  inputs[num_inputs]
   str  output
-  u32  attr0        (v3 only) num_heads for Rope/Attention, else 0
+  u32  attr0        (v3+) num_heads for Rope/Attention, else 0
+  u32  attr1        (v5+) Rope: rotary base θ as IEEE-754 f32 bits (0 = 10000); else 0
 ```
 
 Op signatures: `MatMul(x, W)`, `AddBias(x, b)`, unary activations `(x)`, `Mul(x, y)` / `Add(x, y)` (same shape), `LayerNorm(x, gamma, beta)` and `RmsNorm(x, gamma)` over the last dim, `Rope(x)` (rotary position embedding), and causal `Attention(q, k, v)` (v3, with model-level `seq_len`), plus `Embedding(tokens, table)` (v4). For a token-native model, the graph input is a rank-1 dynamic (`{-1}`) non-const tensor meaning i32 token ids, consumed *only* by embedding ops that gather rows of a constant `[vocab, dim]` table.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -230,16 +230,79 @@ the backend choice must be recorded wherever results are compared (the
 regression gate, checkpoints do not care — the persistent segment is
 backend-neutral f32).
 
-**Phase G1b — engine integration (M).** A backend switch in the engine
-dispatch: GEMM-family opcodes route to the Metal runner, everything else
-stays on CPU (unified memory makes mixed dispatch cheap). Requires
-zero-copy arena buffers (`newBufferWithBytesNoCopy` over a page-aligned
-arena allocation) and batched command encoding instead of G1a's
-one-synchronous-command-per-call harness. **Phase G1c — vendoring (M).**
-The emitted package gains the `.metal` source, the runner TU, and an
-Apple-only branch in the generated `build.sh`, making GPU training a
-run-time flag of `model_update`. Linux GPU (Vulkan) is out of scope until
-a product target needs it.
+> **Status: G1b/G1c PLANNED for v1.3.0 (2026-08-22)** — tracked as
+> milestone *v1.3.0 — GPU fine-tuning* on GitHub: epic #59, phases
+> #60–#64, release gate #65, with #66/#67 on the CPU side. The plan below
+> is priced by the v1.2.4 field report (SeeML CPU 80 tok/s vs MLX GPU
+> 1,605 tok/s on SmolLM-135M) and a Metal-vs-CPU GEMM crossover probe run
+> through the G1a harness at the e2e shapes (table in #59).
+
+**Goal and invariant.** The emitted `model_update` fine-tunes on the GPU
+when one is present, *without loss of generality on CPUs*: the CPU path
+stays the bitwise-deterministic reference, builds anywhere with a C++
+compiler alone, and is bit-identical to v1.2.4 under `--backend cpu`; the
+GPU is an opt-in backend verified against the CPU at tolerance.
+
+**What the probe says (and why the phases are ordered this way).** Through
+the G1a harness — copies and one synchronous command buffer per call — the
+GPU only beats 8 CPU threads above ≈0.3 GFLOP per GEMM (dec_wide-class
+shapes): a ≈0.7 ms per-call floor loses at dec_mid, and SmolLM per-layer
+GEMMs win just 1.0–1.4×. The emitted 16×16 scalar-FMA tile tops out near
+260 GFLOP/s, ≈6 % of the M4's 4.26 TFLOPS — the same "<30 % of peak" band
+the CPU kernels occupy. So zero-copy residency and batched encoding are
+prerequisites, not polish, and `simdgroup_matrix` tiles are on the critical
+path to the 10–20× the frontier comparison prices. A side finding: CPU
+`GemmNT` (the dX backward) runs a serial dot-product chain and is 3–5×
+slower than `GemmNN` at equal FLOPs — most of the bwd/fwd 3.4–4.5× ratio,
+and fixable deterministically on the CPU (#66).
+
+**Phase G1b-1 — backend abstraction (M, #60).** An `ExecutorBackend`
+interface over the opcode families; `CpuBackend` wraps today's kernels
+unchanged; engine dispatch goes through it. `TrainOptions::backend` and a
+`--backend cpu|metal|auto` flag (default `cpu`) in the generated driver,
+`SEEML_BACKEND` env, backend + device recorded in the log banner and
+`report.json` — the per-backend determinism doctrine requires that the
+backend be named wherever results are compared.
+
+**Phase G1b-2 — zero-copy residency (M, #61).** Page-aligned arena
+allocation wrapped once with `newBufferWithBytesNoCopy`; rodata either
+copied once at load or — preferred — the embedded plan page-aligned and
+wrapped no-copy, keeping RSS/(arena+plan) ≈ 1.0. Validator-proven refs
+become `(buffer, offset)`.
+
+**Phase G1b-3 — batched encoding and sync (M, #62).** Consecutive
+GPU-resident instructions encode into one command buffer; a CPU
+instruction touching a region a pending GPU instruction writes (or reads
+a region it writes) forces a flush — the dependency test reuses the
+validator's operand-extent machinery. Tests: Metal run-to-run bitwise on a
+full train program; Metal-vs-CPU loss curves at a stated tolerance; a
+fuzz-style CPU/GPU interleaving test against the pure-CPU run.
+
+**Phase G1b-4 — kernel coverage and quality (L, #63).** In priority
+order: `simdgroup_matrix` GEMM tiles (target ≥ 1.5 TFLOP/s at dec_wide);
+v5 epilogue flags in the write-back; the Q8 GEMMs (the frontier config is
+a q8 base); the attention family; then trivially parallel elementwise /
+norm / RoPE / optimizer kernels so a step has no forced CPU round trips.
+The autotuner learns GPU tile arms.
+
+**Phase G1c — vendoring (M, #64).** The package gains the emitted
+`.metal` source, the runner TU and the backend TU, an Apple-only branch in
+the generated `build.sh` (MSL is JIT-compiled at run time, so no Metal
+toolchain is required), and the `--backend` flag in `update_main.cc`.
+Bundled with it, the field-report P2 fix: **`.incbin` plan embedding**
+(an assembly TU with `.balign 16384` + `.incbin`, decimal `.cc` fallback)
+— the 948 MB decimal TU at 135M parameters took clang 16.5 min; at 1B it
+would not build on a 16 GB host. Page alignment doubles as G1b-2's
+no-copy prerequisite. Linux packages compile exactly the sources they do
+today.
+
+**Release gate (#65).** SmolLM-135M q8 fine-tune: `--backend cpu`
+byte-identical to v1.2.4; `--backend metal` val loss within tolerance and
+≥ 800 tok/s (≥ 10× CPU; MLX is 1,605); package build < 2 min;
+`seeml-bench --backend` baseline rows; docs (runtime, usage,
+SPECIFICATION §7, this file).
+
+Linux GPU (Vulkan) stays out of scope until a product target needs it.
 
 ## Sequencing
 
@@ -247,11 +310,16 @@ a product target needs it.
 2. ~~**4/T1 transformer coverage**~~ — shipped; SMF v3 + plan v6 are in.
 3. ~~**5/G1a Metal dispatch harness**~~ — shipped; the MSL is
    hardware-validated.
-4. **5/G1b engine integration** — the throughput unlock now that the
-   kernels are proven; then **4/T2** scale passes ride it.
-5. **2a gradient accumulation** — unlocks larger effective batches on the
-   devices the memory gate now honestly bounds.
-6. **3 decision (A or B)** — cheap to decide, removes standing dishonesty
+4. **5/G1b-1 → G1b-4, then G1c** (milestone v1.3.0, epic #59) — the
+   throughput unlock, in the dependency order above; **#66 `GemmNT`** and
+   **#67 gate hardening** run alongside on the CPU side.
+5. **4/T2 HF import (#69)** — unblocked by SMF v5's RoPE-base field; rides
+   the GPU backend for frontier-model validation (milestone v1.4.0).
+6. **2a gradient accumulation (#70)** — once the GPU removes the compute
+   wall, activation memory bounds the effective batch on 16 GB devices.
+7. **3 decision (A or B)** — cheap to decide, removes standing dishonesty
    either way.
-7. **2b rematerialization**, then **1b chain fusion**, then **2c bf16** —
-   each contingent on profiling evidence from the phases before it.
+8. **2b rematerialization**, then **1b chain fusion**, then **2c bf16
+   (#71)** — each contingent on profiling evidence from the phases before
+   it; the G1b-4 kernels are written element-type-templated so bf16
+   storage slots in without a second kernel family.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,7 +26,7 @@ python3 tool/export_model.py --demo out/
 
 This writes `model.smf` (a small `Linear(16,32) → ReLU → Linear(32,4)` classifier), `teacher.smf` (a wider sibling, for distillation experiments), and `corpus.sds` (2,048 labeled samples). Everything downstream can be tried against these three files.
 
-Every demo dimension is a flag, so randomized experiments need no bespoke script: `--width`, `--depth`, `--samples`, `--seed`, and `--corpus-kind class|dense|none` (`none` writes the unlabeled corpus that `--loss kl` distillation wants) for `--demo`; add `--vocab`, `--heads`, `--seq-len`, `--blocks`, and `--ffn` for `--demo-decoder`. Defaults reproduce the classic demos byte-for-byte, and — as with `seeml-update-compile` — a flag that cannot apply to the requested mode is a hard error (exit 2), never silently ignored. There is also `--corpus data.npz out.sds`, which converts saved NumPy arrays (`records` for token corpora; `inputs` + optional `labels` for feature corpora) into an SDS file without writing any Python.
+Every demo dimension is a flag, so randomized experiments need no bespoke script: `--width`, `--depth`, `--samples`, `--seed`, and `--corpus-kind class|dense|none` (`none` writes the unlabeled corpus that `--loss kl` distillation wants) for `--demo`; add `--vocab`, `--heads`, `--seq-len`, `--blocks`, `--ffn`, and `--rope-base` (the rotary θ — 10000 by default, 500000 for Llama 3, 1000000 for Qwen; written per Rope op as SMF v5 `attr1` and lowered into the plan verbatim) for `--demo-decoder`. Defaults reproduce the classic demos byte-for-byte, and — as with `seeml-update-compile` — a flag that cannot apply to the requested mode is a hard error (exit 2), never silently ignored. There is also `--corpus data.npz out.sds`, which converts saved NumPy arrays (`records` for token corpora; `inputs` + optional `labels` for feature corpora) into an SDS file without writing any Python.
 
 For your own model, use the two functions the script exports:
 
@@ -38,7 +38,7 @@ export_sds(inputs, labels, "corpus.sds")    # labels: int32 classes, dense f32, 
 
 The exporter accepts an `nn.Sequential` of `Linear`, `ReLU`, `GELU`, `SiLU`, and `LayerNorm` modules — anything else is a loud `ValueError`, not a silent skip. One detail worth knowing so the format makes sense later: PyTorch stores a `Linear`'s weight as `[out, in]`, but SMF's `MatMul(x, W)` wants `[in, out]`, so the exporter transposes on the way out. Labels: pass int32 class indices for cross-entropy, dense float vectors for MSE, or `None` for a distillation corpus (the teacher provides the targets).
 
-**Token-native decoders.** For a decoder transformer that consumes raw token ids (SMF v4), export the frozen embedding table alongside the blocks, and a corpus of plain ids — no labels, no embedded vectors:
+**Token-native decoders.** For a decoder transformer that consumes raw token ids (SMF v4+; the writer emits v5, which adds the per-op RoPE base), export the frozen embedding table alongside the blocks, and a corpus of plain ids — no labels, no embedded vectors:
 
 ```python
 from export_model import export_token_decoder_smf, export_token_sds

--- a/runtime/engine/update_engine.cc
+++ b/runtime/engine/update_engine.cc
@@ -226,7 +226,15 @@ std::expected<void, std::string> UpdateEngine::Initialize(const uint8_t* plan,
 
   // The single allocation of the update: the pre-planned arena. Its size was
   // known at compile time — the device's resource contract.
-  const size_t arena_bytes = (header.arena_size + 63) & ~size_t{63};
+  // Bound before rounding: on a 32-bit host a u64 arena_size past SIZE_MAX
+  // would otherwise truncate into a small allocation the validator's
+  // (u64) bounds proof does not cover — the feeder guards the same class.
+  if (header.arena_size > SIZE_MAX - 64)
+    return diag::executing::Error(
+        "plan arena of " + std::to_string(header.arena_size) +
+        " bytes exceeds this host's address space");
+  const size_t arena_bytes =
+      (static_cast<size_t>(header.arena_size) + 63) & ~size_t{63};
   uint8_t* arena = static_cast<uint8_t*>(std::aligned_alloc(64, arena_bytes));
   if (!arena) return diag::executing::Error("arena allocation failed");
   std::memset(arena, 0, arena_bytes);

--- a/runtime/validator/plan_validator.cc
+++ b/runtime/validator/plan_validator.cc
@@ -1,5 +1,8 @@
 #include "runtime/validator/plan_validator.h"
 
+#include <bit>
+#include <cmath>
+
 #include "runtime/diagnostics/validating/error.h"
 
 namespace seeml::update_rt {
@@ -274,6 +277,13 @@ std::expected<void, std::string> ValidateInstruction(
       if (!attn_geometry(d0, d1, &td, &pn)) return fail();
       // The rotation pairs (2c, 2c+1) require an even head width.
       if ((d1 & 0xFFFFFFFFu) % 2 != 0) return fail();
+      // The rotary base rides out[2] as f32 bits (SMF v5 attr1, or the
+      // lowering default). A non-finite or <= 1 base would make every
+      // angle degenerate or NaN — reject it here, not as a NaN loss later.
+      const float base =
+          std::bit_cast<float>(static_cast<uint32_t>(ins.out[2]));
+      if ((ins.out[2] >> 32) != 0 || !std::isfinite(base) || base <= 1.0f)
+        return fail();
       if (!ref_ok(ins.in[0], td, false) || !ref_ok(ins.in[1], td, true))
         return fail();
       return disjoint();

--- a/source/language/model_format.h
+++ b/source/language/model_format.h
@@ -33,6 +33,7 @@
 //   ops[num_ops] (topologically ordered):
 //     u8 kind; str name; u8 num_inputs; str inputs[num_inputs]; str output;
 //     u32 attr0                                  (v3+ only; per-kind meaning)
+//     u32 attr1                                  (v5+ only; per-kind meaning)
 //   data section: each constant tensor's f32 blob at its 64-aligned data_offset
 //
 // The absolute data_offset of every weight is preserved through compilation —
@@ -49,9 +50,13 @@ inline constexpr uint32_t kSmfMagic = 0x31464D53;  // "SMF1" little-endian
 // output name, and a per-op u32 attr0 word after the output (heads for
 // Rope/Attention, 0 elsewhere). v4 adds kEmbedding — with it, a model may
 // declare a rank-1 dynamic ({-1}) non-const input, meaning i32 token ids
-// consumed exclusively by embedding ops; the byte layout is v3's.
-// Readers accept v1..v4; the writer emits v4.
-inline constexpr uint32_t kSmfVersion = 4;
+// consumed exclusively by embedding ops; the byte layout is v3's. v5 adds
+// a second per-op u32 attr1 after attr0: for kRope it carries the IEEE-754
+// bits of the rotary base θ (0 = the classic 10000); 0 elsewhere. Without
+// it a Llama-3 (θ=500k) or Qwen (θ=1M) port compiled cleanly to the wrong
+// rotation — "unsupported" silently became "wrong".
+// Readers accept v1..v5; the writer emits v5.
+inline constexpr uint32_t kSmfVersion = 5;
 inline constexpr uint32_t kSmfMinVersion = 1;
 
 // SMF is read/written by memcpy of host integers; the documented on-disk
@@ -105,7 +110,14 @@ struct SmfOp {
   // v3: per-kind scalar attribute — num_heads for kRope/kAttention, 0
   // elsewhere (and for every op of a pre-v3 file).
   uint32_t attr0 = 0;
+  // v5: second per-kind scalar — for kRope the f32 bits of the rotary base
+  // θ (0 = kSmfDefaultRopeBase); 0 elsewhere (and for every pre-v5 file).
+  uint32_t attr1 = 0;
 };
+
+/// The rotary base a kRope op means when its attr1 is zero (pre-v5 files,
+/// and v5 writers that leave the default).
+inline constexpr float kSmfDefaultRopeBase = 10000.0f;
 
 /// Immutable once loaded: every consumer (parser, resource analyzer, rodata
 /// packing) takes it by const reference, so one loaded model may be shared

--- a/test/compiler/driver/update_compiler_test.cc
+++ b/test/compiler/driver/update_compiler_test.cc
@@ -4,6 +4,7 @@
 // selection, and the compile-time error surface.
 // =============================================================================
 
+#include <bit>
 #include <cstdint>
 #include <cstring>
 #include <string>
@@ -47,6 +48,29 @@ size_t CountOpcode(const std::vector<UpdateInstruction>& instrs, OpCode oc) {
   for (const UpdateInstruction& ins : instrs)
     if (ins.opcode == static_cast<uint16_t>(oc)) ++n;
   return n;
+}
+
+TEST(UpdateCompiler, RopeBaseReachesForwardAndBackwardInstructions) {
+  // SMF v5 attr1 → parser "base" attribute → autodiff copy → lowering
+  // out[2] on both kRopeFwd and kRopeBwd. A Llama-3-class θ=500k must not
+  // silently lower to 10000 anywhere in the train program.
+  SmfModel model = seeml::testing::MakeTinyDecoder(8, 2, 4, 12, 3, 9);
+  const float theta = 500000.0f;
+  for (SmfOp& op : model.ops)
+    if (op.kind == SmfOpKind::kRope) op.attr1 = std::bit_cast<uint32_t>(theta);
+  ASSERT_OK_AND_ASSIGN(CompiledUpdate compiled,
+                       UpdateCompiler(BaseConfig(8)).Compile(model));
+  const auto instrs = TrainProgramOf(compiled);
+  size_t fwd = 0, bwd = 0;
+  for (const UpdateInstruction& ins : instrs) {
+    const auto op = static_cast<OpCode>(ins.opcode);
+    if (op != OpCode::kRopeFwd && op != OpCode::kRopeBwd) continue;
+    (op == OpCode::kRopeFwd ? fwd : bwd)++;
+    EXPECT_EQ(static_cast<uint32_t>(ins.out[2]),
+              std::bit_cast<uint32_t>(theta));
+  }
+  EXPECT_EQ(fwd, 2u);
+  EXPECT_GE(bwd, 1u);
 }
 
 TEST(UpdateCompiler, PlanHeaderContract) {

--- a/test/compiler/frontend/model_io_test.cc
+++ b/test/compiler/frontend/model_io_test.cc
@@ -200,6 +200,18 @@ TEST(Smf, SaveLoadRoundTripsV5RopeBase) {
   EXPECT_EQ(version, 5u);
 }
 
+TEST(Smf, LoadRejectsAttr1OnKindsThatDoNotDefineIt) {
+  // attr1 is reserved (zero) on every kind but kRope; a file setting it
+  // elsewhere is refused rather than carrying an undefined meaning.
+  ScopedTempDir dir;
+  SmfModel model = seeml::testing::MakeTinyDecoder(8, 2, 4, 12, 3, 9);
+  for (SmfOp& op : model.ops)
+    if (op.kind == SmfOpKind::kAttention) op.attr1 = 1;
+  const std::string path = dir.File("attr1_on_attention.smf");
+  ASSERT_OK(SaveSmf(path, model));
+  EXPECT_ERROR_CONTAINS(LoadSmf(path), "nonzero attr1");
+}
+
 TEST(Smf, SaveComputesAlignedNonOverlappingOffsets) {
   ScopedTempDir dir;
   SmfModel model = MakeMlp(4, 8, 2, 2);

--- a/test/compiler/frontend/model_io_test.cc
+++ b/test/compiler/frontend/model_io_test.cc
@@ -3,6 +3,7 @@
 // rejection of malformed files (the binary-format hardening surface).
 // =============================================================================
 
+#include <bit>
 #include <cstdint>
 #include <fstream>
 #include <string>
@@ -163,6 +164,40 @@ TEST(Smf, SaveLoadRoundTripsV3TransformerFields) {
     EXPECT_EQ(loaded.ops[i].kind, model.ops[i].kind);
     EXPECT_EQ(loaded.ops[i].attr0, model.ops[i].attr0);
   }
+}
+
+TEST(Smf, SaveLoadRoundTripsV5RopeBase) {
+  // The v5 addition — per-op attr1, the rotary base as f32 bits on kRope —
+  // must survive the byte round trip on every op, exactly as written.
+  ScopedTempDir dir;
+  SmfModel model = seeml::testing::MakeTinyDecoder(8, 2, 4, 12, 3, 9);
+  const uint32_t llama3_base = std::bit_cast<uint32_t>(500000.0f);
+  for (SmfOp& op : model.ops)
+    if (op.kind == SmfOpKind::kRope) op.attr1 = llama3_base;
+  const std::string path = dir.File("decoder_v5.smf");
+  ASSERT_OK(SaveSmf(path, model));
+
+  ASSERT_OK_AND_ASSIGN(SmfModel loaded, LoadSmf(path));
+  ASSERT_EQ(loaded.ops.size(), model.ops.size());
+  size_t rope_ops = 0;
+  for (size_t i = 0; i < model.ops.size(); ++i) {
+    EXPECT_EQ(loaded.ops[i].attr1, model.ops[i].attr1);
+    if (loaded.ops[i].kind == SmfOpKind::kRope) {
+      ++rope_ops;
+      EXPECT_EQ(loaded.ops[i].attr1, llama3_base);
+    } else {
+      EXPECT_EQ(loaded.ops[i].attr1, 0u);
+    }
+  }
+  EXPECT_EQ(rope_ops, 2u);
+  // The writer stamps the current version.
+  std::ifstream f(path, std::ios::binary);
+  uint32_t magic = 0, version = 0;
+  f.read(reinterpret_cast<char*>(&magic), sizeof(magic));
+  f.read(reinterpret_cast<char*>(&version), sizeof(version));
+  EXPECT_EQ(magic, kSmfMagic);
+  EXPECT_EQ(version, kSmfVersion);
+  EXPECT_EQ(version, 5u);
 }
 
 TEST(Smf, SaveComputesAlignedNonOverlappingOffsets) {

--- a/test/compiler/frontend/parser_test.cc
+++ b/test/compiler/frontend/parser_test.cc
@@ -4,6 +4,7 @@
 // teacher-prefix namespacing used by distillation.
 // =============================================================================
 
+#include <bit>
 #include <cstdint>
 #include <string>
 #include <thread>
@@ -458,6 +459,52 @@ TEST(ForwardBuilder, RejectsBatchNotWholeSequences) {
   build.input = block.addArgument(sir::DataType::F32, sir::Shape{6, 8});
   EXPECT_ERROR_CONTAINS(BuildForward(block, model, "", build.input, 6, build),
                         "whole number of sequences");
+}
+
+TEST(ForwardBuilder, RopeBaseAttributeComesFromAttr1) {
+  // v5 attr1 carries the rotary base as f32 bits; zero (every pre-v5 file)
+  // means the classic 10000. Autodiff copies "base" onto the backward and
+  // lowering packs it into kRopeFwd/kRopeBwd out[2] — so the whole θ path
+  // starts here.
+  SmfModel model = seeml::testing::MakeTinyDecoder(8, 2, 4, 12, 3, 7);
+  for (SmfOp& op : model.ops)
+    if (op.kind == SmfOpKind::kRope && op.name == "ropeq")
+      op.attr1 = std::bit_cast<uint32_t>(500000.0f);
+  sir::Block block;
+  GraphBuild build;
+  build.input = block.addArgument(sir::DataType::F32, sir::Shape{8, 8});
+  ASSERT_OK(BuildForward(block, model, "", build.input, 8, build));
+  size_t seen = 0;
+  block.walk([&](sir::Operation* op) {
+    if (op->mnemonic() != "sc_high.rope") return;
+    ++seen;
+    const float base = op->getAttrAs<float>("base").value_or(-1.0f);
+    if (op->result(0)->id() == "qr")
+      EXPECT_EQ(base, 500000.0f);
+    else
+      EXPECT_EQ(base, 10000.0f);
+  });
+  EXPECT_EQ(seen, 2u);
+}
+
+TEST(ForwardBuilder, RejectsRopeWithDegenerateBase) {
+  SmfModel model = seeml::testing::MakeTinyDecoder(8, 2, 4, 12, 3, 7);
+  for (SmfOp& op : model.ops)
+    if (op.kind == SmfOpKind::kRope) op.attr1 = std::bit_cast<uint32_t>(1.0f);
+  sir::Block block;
+  GraphBuild build;
+  build.input = block.addArgument(sir::DataType::F32, sir::Shape{8, 8});
+  EXPECT_ERROR_CONTAINS(BuildForward(block, model, "", build.input, 8, build),
+                        "rotary base");
+  SmfModel nan_model = seeml::testing::MakeTinyDecoder(8, 2, 4, 12, 3, 7);
+  for (SmfOp& op : nan_model.ops)
+    if (op.kind == SmfOpKind::kRope) op.attr1 = 0x7FC00000u;  // quiet NaN
+  sir::Block block2;
+  GraphBuild build2;
+  build2.input = block2.addArgument(sir::DataType::F32, sir::Shape{8, 8});
+  EXPECT_ERROR_CONTAINS(
+      BuildForward(block2, nan_model, "", build2.input, 8, build2),
+      "rotary base");
 }
 
 TEST(ForwardBuilder, RejectsRopeWithOddHeadWidth) {

--- a/test/runtime/validator/validator_test.cc
+++ b/test/runtime/validator/validator_test.cc
@@ -5,6 +5,7 @@
 // regression that every instruction the compiler emits validates.
 // =============================================================================
 
+#include <bit>
 #include <cstdint>
 #include <cstring>
 #include <vector>
@@ -151,10 +152,36 @@ TEST(PlanValidator, RopeRequiresEvenHeadWidth) {
   rope.in[1] = up::MakeArenaRef(96);
   rope.out[0] = (uint64_t{1} << 32) | 2;  // B=1, S=2
   rope.out[1] = (uint64_t{2} << 32) | 3;  // H=2, d=3: odd head width
+  rope.out[2] = std::bit_cast<uint32_t>(10000.0f);
   EXPECT_ERROR(ValidateInstruction(rope, kArena, kRodata, up::kSeeuVersion));
   rope.out[1] = (uint64_t{2} << 32) | 4;  // d=4 with disjoint in/out
   rope.in[1] = up::MakeArenaRef(512);
   EXPECT_OK(ValidateInstruction(rope, kArena, kRodata, up::kSeeuVersion));
+}
+
+TEST(PlanValidator, RopeBaseMustBeAUsableFloat) {
+  // out[2] carries the rotary base as f32 bits (SMF v5 attr1 → lowering).
+  // A zero, NaN, infinite, or <= 1 base makes every angle degenerate; a
+  // stray high word means the word was not written by this lowering.
+  up::UpdateInstruction rope;
+  rope.opcode = static_cast<uint16_t>(up::OpCode::kRopeBwd);
+  rope.in[0] = up::MakeArenaRef(0);
+  rope.in[1] = up::MakeArenaRef(512);
+  rope.out[0] = (uint64_t{1} << 32) | 2;  // B=1, S=2
+  rope.out[1] = (uint64_t{2} << 32) | 4;  // H=2, d=4
+  for (const float ok_base : {10000.0f, 500000.0f, 1000000.0f, 1.5f}) {
+    rope.out[2] = std::bit_cast<uint32_t>(ok_base);
+    EXPECT_OK(ValidateInstruction(rope, kArena, kRodata, up::kSeeuVersion));
+  }
+  for (const uint64_t bad : {uint64_t{0}, uint64_t{0x7FC00000u},
+                             uint64_t{0x7F800000u},
+                             uint64_t{std::bit_cast<uint32_t>(1.0f)},
+                             uint64_t{std::bit_cast<uint32_t>(-10000.0f)},
+                             (uint64_t{1} << 32) |
+                                 std::bit_cast<uint32_t>(10000.0f)}) {
+    rope.out[2] = bad;
+    EXPECT_ERROR(ValidateInstruction(rope, kArena, kRodata, up::kSeeuVersion));
+  }
 }
 
 TEST(PlanValidator, RejectsReadsPastTheArena) {

--- a/tool/bench_compare.py
+++ b/tool/bench_compare.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-"""Gate a seeml-bench run against a stored baseline (stdlib only).
+"""Gate a seeml-bench run against stored baselines (stdlib only).
 
 Usage:
-    python3 bench_compare.py baseline.json current.json [--max-regression F]
+    python3 bench_compare.py baseline.json current.json
+        [--max-regression F] [--epoch-baseline epoch.json]
+        [--max-epoch-regression F]
 
 Compares the Tier A throughput metric — rows_per_s, per fixture per thread
 width — and exits 1 if any pair regressed by more than --max-regression
@@ -10,8 +12,19 @@ width — and exits 1 if any pair regressed by more than --max-regression
 file exits 0 with a note: the first run of a new host seeds the baseline
 rather than failing it. Fixtures or thread widths present on only one side
 are reported and skipped — adding a fixture must not fail the night it
-lands. Everything is medians-of-medians upstream, so a >10% delta is
-signal, not noise.
+lands — but a comparison with NO overlapping keys is an error (exit 1),
+not a pass: after a key rename the gate would otherwise be blind forever
+while printing "no regression".
+
+The rolling baseline (last green night) catches step changes; a slow
+compounding drift of <10%/night would never trip it. --epoch-baseline names
+a second, pinned report that is never rolled forward — the gate also diffs
+against it (--max-epoch-regression, default 0.15) so drift accumulates
+against a fixed reference. A missing epoch file is a note, not a failure
+(the workflow seeds it once).
+
+Everything is medians-of-medians upstream, so a >10% delta is signal, not
+noise.
 """
 import argparse
 import json
@@ -28,48 +41,100 @@ def tier_a(report):
     return out
 
 
-def main():
-    p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("baseline")
-    p.add_argument("current")
-    p.add_argument("--max-regression", type=float, default=0.10,
-                   help="fractional Tier A loss that fails the gate (0.10)")
-    args = p.parse_args()
+def load(path):
+    with open(path) as f:
+        return tier_a(json.load(f))
 
-    if not os.path.exists(args.baseline):
-        print(f"bench_compare: no baseline at {args.baseline} — "
-              "this run seeds it")
-        return 0
-    with open(args.baseline) as f:
-        base = tier_a(json.load(f))
-    with open(args.current) as f:
-        cur = tier_a(json.load(f))
 
-    failures, skipped = [], []
+def compare(label, base, cur, max_regression):
+    """Prints per-key lines; returns (failures, compared_count)."""
+    failures, skipped, compared = [], [], 0
     for key, base_v in sorted(base.items()):
         if key not in cur:
-            skipped.append(f"{key[0]}@{key[1]}t: in baseline only")
+            skipped.append(f"{key[0]}@{key[1]}t: in {label} only")
             continue
+        compared += 1
         cur_v = cur[key]
         delta = (cur_v - base_v) / base_v if base_v > 0 else 0.0
         line = (f"{key[0]}@{key[1]}t: {base_v:.0f} -> {cur_v:.0f} rows/s "
-                f"({delta:+.1%})")
-        if delta < -args.max_regression:
+                f"({delta:+.1%}) vs {label}")
+        if delta < -max_regression:
             failures.append(line)
         else:
             print(f"bench_compare: OK   {line}")
     for key in sorted(cur.keys() - base.keys()):
-        skipped.append(f"{key[0]}@{key[1]}t: new, no baseline")
+        skipped.append(f"{key[0]}@{key[1]}t: new, not in {label}")
     for s in skipped:
         print(f"bench_compare: SKIP {s}")
     for f_ in failures:
         print(f"bench_compare: FAIL {f_}")
-    if failures:
-        print(f"bench_compare: {len(failures)} Tier A metric(s) regressed "
-              f"more than {args.max_regression:.0%}")
+    return failures, compared
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("baseline")
+    p.add_argument("current")
+    p.add_argument("--max-regression", type=float, default=0.10,
+                   help="fractional Tier A loss vs the rolling baseline "
+                        "that fails the gate (0.10)")
+    p.add_argument("--epoch-baseline", metavar="PATH", default=None,
+                   help="pinned report that is never rolled forward; "
+                        "guards against compounding drift")
+    p.add_argument("--max-epoch-regression", type=float, default=0.15,
+                   help="fractional Tier A loss vs the epoch baseline that "
+                        "fails the gate (0.15)")
+    args = p.parse_args()
+
+    cur = load(args.current)
+    if not cur:
+        print(f"bench_compare: ERROR current report {args.current} carries "
+              "no Tier A metrics")
         return 1
-    print("bench_compare: no Tier A regression")
-    return 0
+
+    status = 0
+    if not os.path.exists(args.baseline):
+        print(f"bench_compare: no baseline at {args.baseline} — "
+              "this run seeds it")
+    else:
+        base = load(args.baseline)
+        failures, compared = compare("baseline", base, cur,
+                                     args.max_regression)
+        if compared == 0:
+            # Fail closed: zero overlap means the gate measured nothing.
+            print("bench_compare: ERROR no Tier A metric is present in both "
+                  "the baseline and the current report — the gate would be "
+                  "blind; re-seed the baseline deliberately if the keys "
+                  "were renamed")
+            return 1
+        if failures:
+            print(f"bench_compare: {len(failures)} Tier A metric(s) regressed "
+                  f"more than {args.max_regression:.0%} vs the rolling "
+                  "baseline")
+            status = 1
+
+    if args.epoch_baseline is not None:
+        if not os.path.exists(args.epoch_baseline):
+            print(f"bench_compare: no epoch baseline at "
+                  f"{args.epoch_baseline} — this run seeds it")
+        else:
+            epoch = load(args.epoch_baseline)
+            failures, compared = compare("epoch", epoch, cur,
+                                         args.max_epoch_regression)
+            if compared == 0:
+                print("bench_compare: ERROR no Tier A metric is present in "
+                      "both the epoch baseline and the current report")
+                return 1
+            if failures:
+                print(f"bench_compare: {len(failures)} Tier A metric(s) "
+                      f"regressed more than {args.max_epoch_regression:.0%} "
+                      "vs the pinned epoch baseline (compounding drift)")
+                status = 1
+
+    if status == 0:
+        print("bench_compare: no Tier A regression")
+    return status
 
 
 if __name__ == "__main__":

--- a/tool/export_model.py
+++ b/tool/export_model.py
@@ -53,7 +53,8 @@ import struct
 import sys
 
 SMF_MAGIC = 0x31464D53  # "SMF1"
-SMF_VERSION = 3         # v3: transformer op kinds, seq_len, per-op attr0
+SMF_VERSION = 5         # v5: per-op attr1 (RoPE base as f32 bits) after attr0
+DEFAULT_ROPE_BASE = 10000.0  # what attr1 == 0 means on a Rope op
 SDS_MAGIC = 0x31534453  # "SDS1"
 ALIGN = 64
 
@@ -77,9 +78,10 @@ class _SmfBuilder:
         self.input_name = input_name
         self.output_name = input_name
         self.seq_len = seq_len  # rows per sequence; 0 = non-sequential
-        # A token-native model (SMF v4) declares a rank-1 dynamic input:
-        # one i32 token id per row, gathered on-device by kEmbedding.
-        self.version = 4 if token_input else SMF_VERSION
+        # A token-native model (SMF v4+) declares a rank-1 dynamic input:
+        # one i32 token id per row, gathered on-device by kEmbedding. Every
+        # file is written at the current version; readers accept v1..v5.
+        self.version = SMF_VERSION
         dims = [-1] if token_input else [-1, input_dim]
         self.tensors = [dict(name=input_name, dims=dims, const=False, data=b"")]
         self.ops = []
@@ -87,9 +89,10 @@ class _SmfBuilder:
     def add_tensor(self, name, dims, data: bytes):
         self.tensors.append(dict(name=name, dims=list(dims), const=True, data=data))
 
-    def add_op(self, kind, name, inputs, output, attr0: int = 0):
+    def add_op(self, kind, name, inputs, output, attr0: int = 0,
+               attr1: int = 0):
         self.ops.append(dict(kind=kind, name=name, inputs=inputs,
-                             output=output, attr0=attr0))
+                             output=output, attr0=attr0, attr1=attr1))
         self.output_name = output
 
     def serialize(self) -> bytes:
@@ -111,6 +114,7 @@ class _SmfBuilder:
                     out += _s(i)
                 out += _s(op["output"])
                 out += struct.pack("<I", op["attr0"])
+                out += struct.pack("<I", op["attr1"])  # v5
             return out
 
         meta_size = len(meta({}))
@@ -195,9 +199,26 @@ def _decoder_dim(blocks, head, num_heads: int, caller: str) -> int:
     return D
 
 
-def _emit_decoder_graph(b, blocks, head, num_heads: int, prev: str):
+def _rope_base_bits(rope_base: float) -> int:
+    """attr1 encoding of a rotary base: its IEEE-754 single bits, exactly as
+    the on-device kernel will read them (0 would mean the 10000 default)."""
+    import math
+    base = float(rope_base)
+    if not math.isfinite(base) or base <= 1.0:
+        raise ValueError(f"rope_base must be a finite float > 1, got {rope_base}")
+    # Round-trip through f32 so the exporter's notion of θ matches the
+    # kernel's: a base that is not exactly representable is rounded once,
+    # here, and the rounded value is what gets written.
+    bits = struct.unpack("<I", struct.pack("<f", base))[0]
+    return bits
+
+
+def _emit_decoder_graph(b, blocks, head, num_heads: int, prev: str,
+                        rope_base: float = DEFAULT_ROPE_BASE):
     """Append the pre-norm block stack and lm head, reading rows from `prev`."""
     import numpy as np
+
+    base_bits = _rope_base_bits(rope_base)
 
     def tensor(name, arr):
         a = np.ascontiguousarray(np.asarray(arr, dtype=np.float32))
@@ -211,8 +232,10 @@ def _emit_decoder_graph(b, blocks, head, num_heads: int, prev: str):
         for w in ("wq", "wk", "wv"):
             tensor(p + w, blk[w])
             b.add_op(OP_MATMUL, p + "mm_" + w, [p + "n1", p + w], p + w[1])
-        b.add_op(OP_ROPE, p + "rope_q", [p + "q"], p + "qr", attr0=num_heads)
-        b.add_op(OP_ROPE, p + "rope_k", [p + "k"], p + "kr", attr0=num_heads)
+        b.add_op(OP_ROPE, p + "rope_q", [p + "q"], p + "qr", attr0=num_heads,
+                 attr1=base_bits)
+        b.add_op(OP_ROPE, p + "rope_k", [p + "k"], p + "kr", attr0=num_heads,
+                 attr1=base_bits)
         b.add_op(OP_ATTENTION, p + "attn", [p + "qr", p + "kr", p + "v"],
                  p + "a", attr0=num_heads)
         tensor(p + "wo", blk["wo"])
@@ -238,8 +261,13 @@ def _emit_decoder_graph(b, blocks, head, num_heads: int, prev: str):
 
 
 def export_decoder_smf(blocks, head, path: str, seq_len: int, num_heads: int,
-                       input_name: str = "x"):
-    """Export a pre-norm causal decoder stack to SMF v3.
+                       input_name: str = "x",
+                       rope_base: float = DEFAULT_ROPE_BASE):
+    """Export a pre-norm causal decoder stack to SMF v5.
+
+    `rope_base` is the rotary θ (HF `rope_theta`): 10000 for GPT-NeoX /
+    SmolLM-v1, 100000 for SmolLM2, 500000 for Llama 3.x, 1000000 for Qwen.
+    It is written per Rope op (attr1) and lowered into the plan verbatim.
 
     `blocks` is a list of dicts of float32 numpy arrays, one per layer:
         ln1_g [D]; wq, wk, wv, wo [D, D]; ln2_g [D];
@@ -252,16 +280,18 @@ def export_decoder_smf(blocks, head, path: str, seq_len: int, num_heads: int,
     """
     D = _decoder_dim(blocks, head, num_heads, "export_decoder_smf")
     b = _SmfBuilder(input_name, D, seq_len=seq_len)
-    _emit_decoder_graph(b, blocks, head, num_heads, prev=input_name)
+    _emit_decoder_graph(b, blocks, head, num_heads, prev=input_name,
+                        rope_base=rope_base)
     with open(path, "wb") as f:
         f.write(b.serialize())
     print(f"wrote {path} ({len(blocks)} decoder blocks, seq_len={seq_len}, "
-          f"heads={num_heads})")
+          f"heads={num_heads}, rope_base={float(rope_base):g})")
 
 
 def export_token_decoder_smf(embedding, blocks, head, path: str, seq_len: int,
-                             num_heads: int, input_name: str = "x"):
-    """Export a token-native pre-norm causal decoder to SMF v4.
+                             num_heads: int, input_name: str = "x",
+                             rope_base: float = DEFAULT_ROPE_BASE):
+    """Export a token-native pre-norm causal decoder to SMF v5.
 
     Same `blocks` / `head` dictionaries as export_decoder_smf, plus
     `embedding`: a float32 [V, D] table. The exported model's input is a
@@ -282,11 +312,13 @@ def export_token_decoder_smf(embedding, blocks, head, path: str, seq_len: int,
     b = _SmfBuilder(input_name, D, seq_len=seq_len, token_input=True)
     b.add_tensor("emb", list(emb.shape), emb.tobytes())
     b.add_op(OP_EMBEDDING, "embed", [input_name, "emb"], "e")
-    _emit_decoder_graph(b, blocks, head, num_heads, prev="e")
+    _emit_decoder_graph(b, blocks, head, num_heads, prev="e",
+                        rope_base=rope_base)
     with open(path, "wb") as f:
         f.write(b.serialize())
     print(f"wrote {path} ({len(blocks)} decoder blocks, seq_len={seq_len}, "
-          f"heads={num_heads}, vocab={emb.shape[0]}, token-native)")
+          f"heads={num_heads}, vocab={emb.shape[0]}, token-native, "
+          f"rope_base={float(rope_base):g})")
 
 
 def export_sds(inputs, labels, path: str, label_kind: int = 1):
@@ -329,7 +361,20 @@ def export_token_sds(records, path: str):
     """
     import numpy as np
 
-    a = np.ascontiguousarray(np.asarray(records, dtype=np.int32))
+    raw = np.asarray(records)
+    if np.issubdtype(raw.dtype, np.floating):
+        # A float array here is almost always a mistake (a logits/embedding
+        # array handed where ids belong); silently truncating 3.7 → 3 would
+        # train on garbage labels. Exact integers in float dtype are fine.
+        if not np.all(np.isfinite(raw)) or not np.all(np.mod(raw, 1) == 0):
+            raise ValueError("export_token_sds: records must be integer "
+                             "token ids (got non-integral float values)")
+    elif not (np.issubdtype(raw.dtype, np.integer) or raw.size == 0):
+        raise ValueError("export_token_sds: records must be integer token "
+                         f"ids (got dtype {raw.dtype})")
+    if raw.size and raw.max() > np.iinfo(np.int32).max:
+        raise ValueError("export_token_sds: token id exceeds int32")
+    a = np.ascontiguousarray(raw.astype(np.int32))
     if a.ndim != 2 or a.shape[1] < 2:
         raise ValueError("export_token_sds: records must be [N, seq_len + 1]")
     if a.shape[0] == 0:
@@ -376,7 +421,8 @@ def _demo(out_dir: str, width: int = 32, depth: int = 1, samples: int = 2048,
 
 def _demo_decoder(out_dir: str, vocab: int = 50, dim: int = 32,
                   heads: int = 4, seq: int = 8, ffn: int = 0,
-                  blocks_n: int = 2, samples: int = 192, seed: int = 0):
+                  blocks_n: int = 2, samples: int = 192, seed: int = 0,
+                  rope_base: float = DEFAULT_ROPE_BASE):
     """A tiny token-native decoder plus a corpus it can actually learn:
     a cyclic-successor language where token t is always followed by
     (t + 3) % vocab. Needs NumPy only — no PyTorch."""
@@ -397,7 +443,7 @@ def _demo_decoder(out_dir: str, vocab: int = 50, dim: int = 32,
     head = {"lnf_g": np.ones(dim, np.float32), "w_head": mat(dim, vocab)}
     emb = (rng.standard_normal((vocab, dim)) * 0.5).astype(np.float32)
     export_token_decoder_smf(emb, blocks, head, f"{out_dir}/decoder.smf",
-                             seq_len=seq, num_heads=heads)
+                             seq_len=seq, num_heads=heads, rope_base=rope_base)
 
     starts = rng.integers(0, vocab, samples)
     records = (starts[:, None] + 3 * np.arange(seq + 1)) % vocab
@@ -470,7 +516,13 @@ if __name__ == "__main__":
                         help="--demo-decoder only: decoder blocks (2)")
     parser.add_argument("--ffn", type=int, metavar="N",
                         help="--demo-decoder only: FFN width (2x width)")
+    parser.add_argument("--rope-base", type=float, metavar="THETA",
+                        help="--demo-decoder only: rotary base θ (HF "
+                             "rope_theta; default 10000 — 500000 for Llama 3, "
+                             "1000000 for Qwen)")
     args = parser.parse_args()
+    if args.rope_base is not None and not args.rope_base > 1.0:
+        parser.error(f"--rope-base must be > 1, got {args.rope_base}")
 
     if not args.demo and not args.demo_decoder and not args.corpus:
         parser.print_help()
@@ -516,6 +568,8 @@ if __name__ == "__main__":
         _demo_decoder(args.demo_decoder, vocab=args.vocab or 50, dim=dim,
                       heads=heads, seq=args.seq_len or 8, ffn=args.ffn or 0,
                       blocks_n=args.blocks or 2, samples=args.samples or 192,
-                      seed=args.seed if args.seed is not None else 0)
+                      seed=args.seed if args.seed is not None else 0,
+                      rope_base=(args.rope_base if args.rope_base is not None
+                                 else DEFAULT_ROPE_BASE))
     if args.corpus:
         _export_corpus(args.corpus[0], args.corpus[1])

--- a/tool/export_model.py
+++ b/tool/export_model.py
@@ -55,6 +55,10 @@ import sys
 SMF_MAGIC = 0x31464D53  # "SMF1"
 SMF_VERSION = 5         # v5: per-op attr1 (RoPE base as f32 bits) after attr0
 DEFAULT_ROPE_BASE = 10000.0  # what attr1 == 0 means on a Rope op
+# The writer emits the LOWEST version that can carry the model: v3 for a
+# feature-input model, v4 for a token-native one, v5 only when some Rope op
+# carries a non-default base (attr1 != 0). Files that use nothing newer keep
+# loading on older compilers, and the classic demos stay byte-for-byte.
 SDS_MAGIC = 0x31534453  # "SDS1"
 ALIGN = 64
 
@@ -79,9 +83,8 @@ class _SmfBuilder:
         self.output_name = input_name
         self.seq_len = seq_len  # rows per sequence; 0 = non-sequential
         # A token-native model (SMF v4+) declares a rank-1 dynamic input:
-        # one i32 token id per row, gathered on-device by kEmbedding. Every
-        # file is written at the current version; readers accept v1..v5.
-        self.version = SMF_VERSION
+        # one i32 token id per row, gathered on-device by kEmbedding.
+        self.min_version = 4 if token_input else 3
         dims = [-1] if token_input else [-1, input_dim]
         self.tensors = [dict(name=input_name, dims=dims, const=False, data=b"")]
         self.ops = []
@@ -95,9 +98,16 @@ class _SmfBuilder:
                              output=output, attr0=attr0, attr1=attr1))
         self.output_name = output
 
+    @property
+    def version(self) -> int:
+        needs_v5 = any(op["attr1"] != 0 for op in self.ops)
+        return max(self.min_version, 5 if needs_v5 else 3)
+
     def serialize(self) -> bytes:
+        version = self.version
+
         def meta(offsets):
-            out = struct.pack("<IIII", SMF_MAGIC, self.version,
+            out = struct.pack("<IIII", SMF_MAGIC, version,
                               len(self.tensors), len(self.ops))
             out += _s(self.input_name) + _s(self.output_name)
             out += struct.pack("<Q", self.seq_len)
@@ -114,7 +124,8 @@ class _SmfBuilder:
                     out += _s(i)
                 out += _s(op["output"])
                 out += struct.pack("<I", op["attr0"])
-                out += struct.pack("<I", op["attr1"])  # v5
+                if version >= 5:
+                    out += struct.pack("<I", op["attr1"])
             return out
 
         meta_size = len(meta({}))
@@ -208,9 +219,21 @@ def _rope_base_bits(rope_base: float) -> int:
         raise ValueError(f"rope_base must be a finite float > 1, got {rope_base}")
     # Round-trip through f32 so the exporter's notion of θ matches the
     # kernel's: a base that is not exactly representable is rounded once,
-    # here, and the rounded value is what gets written.
-    bits = struct.unpack("<I", struct.pack("<f", base))[0]
-    return bits
+    # here, and the rounded value is what gets written — so the checks
+    # must hold for the ROUNDED value (1 + 2^-24 rounds to exactly 1.0f;
+    # > FLT_MAX rounds to inf), or the compiler's sema would be the first
+    # to notice.
+    try:
+        packed = struct.pack("<f", base)
+    except OverflowError:
+        raise ValueError(f"rope_base {rope_base} exceeds float32 range")
+    rounded = struct.unpack("<f", packed)[0]
+    if not math.isfinite(rounded) or rounded <= 1.0:
+        raise ValueError(f"rope_base {rope_base} rounds to {rounded} in "
+                         "float32, which is not a usable base (> 1)")
+    if rounded == DEFAULT_ROPE_BASE:
+        return 0  # the format default; keeps such files at SMF v3/v4
+    return struct.unpack("<I", packed)[0]
 
 
 def _emit_decoder_graph(b, blocks, head, num_heads: int, prev: str,
@@ -372,8 +395,9 @@ def export_token_sds(records, path: str):
     elif not (np.issubdtype(raw.dtype, np.integer) or raw.size == 0):
         raise ValueError("export_token_sds: records must be integer token "
                          f"ids (got dtype {raw.dtype})")
-    if raw.size and raw.max() > np.iinfo(np.int32).max:
-        raise ValueError("export_token_sds: token id exceeds int32")
+    if raw.size and (raw.max() > np.iinfo(np.int32).max or
+                     raw.min() < np.iinfo(np.int32).min):
+        raise ValueError("export_token_sds: token id does not fit int32")
     a = np.ascontiguousarray(raw.astype(np.int32))
     if a.ndim != 2 or a.shape[1] < 2:
         raise ValueError("export_token_sds: records must be [N, seq_len + 1]")
@@ -521,8 +545,11 @@ if __name__ == "__main__":
                              "rope_theta; default 10000 — 500000 for Llama 3, "
                              "1000000 for Qwen)")
     args = parser.parse_args()
-    if args.rope_base is not None and not args.rope_base > 1.0:
-        parser.error(f"--rope-base must be > 1, got {args.rope_base}")
+    if args.rope_base is not None:
+        try:
+            _rope_base_bits(args.rope_base)
+        except ValueError as e:
+            parser.error(f"--rope-base: {e}")
 
     if not args.demo and not args.demo_decoder and not args.corpus:
         parser.print_help()
@@ -541,7 +568,7 @@ if __name__ == "__main__":
              depth=args.depth, corpus_kind=args.corpus_kind)
     _require(args.demo_decoder, "--demo-decoder", vocab=args.vocab,
              heads=args.heads, seq_len=args.seq_len, blocks=args.blocks,
-             ffn=args.ffn)
+             ffn=args.ffn, rope_base=args.rope_base)
     _require(args.demo or args.demo_decoder, "--demo or --demo-decoder",
              width=args.width, samples=args.samples, seed=args.seed)
     for name in ("samples", "width", "depth", "vocab", "heads", "seq_len",

--- a/tool/seeml_bench.cc
+++ b/tool/seeml_bench.cc
@@ -51,7 +51,11 @@ double MsSince(Clock::time_point t0) {
 
 double Median(std::vector<double> v) {
   std::sort(v.begin(), v.end());
-  return v[v.size() / 2];
+  const size_t n = v.size();
+  // Even counts take the mean of the two middle samples — the textbook
+  // median, rather than a biased upper-middle. Odd counts (the default
+  // repeats=3) are unaffected, so stored baselines stay comparable.
+  return n % 2 == 1 ? v[n / 2] : 0.5 * (v[n / 2 - 1] + v[n / 2]);
 }
 
 // --- The standard fixture set -----------------------------------------------
@@ -145,7 +149,10 @@ std::expected<uint64_t, std::string> ParseU64(const std::string& flag,
   for (char c : v) {
     if (c < '0' || c > '9')
       return std::unexpected(flag + ": '" + v + "' is not a whole number");
-    out = out * 10 + static_cast<uint64_t>(c - '0');
+    const auto digit = static_cast<uint64_t>(c - '0');
+    if (out > (UINT64_MAX - digit) / 10)
+      return std::unexpected(flag + ": '" + v + "' does not fit 64 bits");
+    out = out * 10 + digit;
   }
   if (out == 0) return std::unexpected(flag + " must be >= 1");
   return out;
@@ -230,8 +237,25 @@ int main(int argc, char** argv) {
     }
   }
 
-  FILE* out = std::fopen(out_path->c_str(), "w");
-  if (!out) return Fail("cannot open '" + *out_path + "' for writing");
+  // Stage the report beside its destination and rename it into place only
+  // when every fixture completed: a failed run must not leave a truncated
+  // bench.json that a later gate could mistake for a report (nor a stray
+  // checkpoint temp), so both are cleaned up on any early return.
+  const std::string tmp_path = *out_path + ".tmp";
+  struct Staging {
+    std::string tmp, ckpt;
+    FILE* file = nullptr;
+    bool committed = false;
+    ~Staging() {
+      if (committed) return;
+      if (file) std::fclose(file);
+      std::remove(tmp.c_str());
+      if (!ckpt.empty()) std::remove(ckpt.c_str());
+    }
+  } staging{tmp_path, "", nullptr, false};
+  FILE* out = std::fopen(tmp_path.c_str(), "w");
+  if (!out) return Fail("cannot open '" + tmp_path + "' for writing");
+  staging.file = out;
   std::fprintf(out,
                "{\n  \"seeml_version\": \"%s\",\n  \"schema\": 1,\n"
                "  \"config\": {\"steps_lo\": %" PRIu64 ", \"steps_hi\": %"
@@ -338,11 +362,13 @@ int main(int argc, char** argv) {
       return Fail(f->name + (": " + ok.error()));
     const double merge_ms = MsSince(t_merge);
     const std::string ckpt = *out_path + "." + f->name + ".ckpt.tmp";
+    staging.ckpt = ckpt;
     const auto t_ckpt = Clock::now();
     if (auto ok = engine.SaveCheckpoint(ckpt); !ok)
       return Fail(f->name + (": " + ok.error()));
     const double ckpt_ms = MsSince(t_ckpt);
     std::remove(ckpt.c_str());
+    staging.ckpt.clear();
     std::fprintf(out,
                  "\n      },\n      \"merge_ms\": %.3f, "
                  "\"checkpoint_save_ms\": %.3f\n    }",
@@ -352,8 +378,14 @@ int main(int argc, char** argv) {
   std::fprintf(out, "\n  }\n}\n");
   // A truncated report must not exit 0 — same discipline as --report in
   // seeml-update-compile.
-  if (std::ferror(out) || std::fclose(out) != 0)
-    return Fail("failed writing '" + *out_path + "'");
+  const bool write_failed = std::ferror(out) != 0;
+  const bool close_failed = std::fclose(out) != 0;
+  staging.file = nullptr;
+  if (write_failed || close_failed)
+    return Fail("failed writing '" + tmp_path + "'");
+  if (std::rename(tmp_path.c_str(), out_path->c_str()) != 0)
+    return Fail("cannot move '" + tmp_path + "' to '" + *out_path + "'");
+  staging.committed = true;
   std::fprintf(stderr, "seeml-bench: wrote %s\n", out_path->c_str());
   return 0;
 }

--- a/tool/seeml_bench.cc
+++ b/tool/seeml_bench.cc
@@ -54,7 +54,9 @@ double Median(std::vector<double> v) {
   const size_t n = v.size();
   // Even counts take the mean of the two middle samples — the textbook
   // median, rather than a biased upper-middle. Odd counts (the default
-  // repeats=3) are unaffected, so stored baselines stay comparable.
+  // repeats=3, which CI uses) are unaffected. A baseline recorded with an
+  // EVEN --repeats by an older binary is not comparable to this one —
+  // re-seed it (nightly: workflow_dispatch with reseed_baseline=true).
   return n % 2 == 1 ? v[n / 2] : 0.5 * (v[n / 2 - 1] + v[n / 2]);
 }
 

--- a/tool/seeml_seeu_dump.cc
+++ b/tool/seeml_seeu_dump.cc
@@ -348,18 +348,30 @@ int main(int argc, char** argv) {
   }
 
   if (want_instrs) {
-    auto stream = [&](uint64_t off) {
-      return reinterpret_cast<const UpdateInstruction*>(plan.data() + off);
+    // Copy each stream out before decoding: a corrupt header may place an
+    // offset at any alignment, and a reinterpret_cast there is UB (and a
+    // real SIGBUS on strict-alignment targets). The dumper's job is to
+    // describe bad plans, not to crash on them.
+    std::vector<UpdateInstruction> copy;
+    auto stream = [&](uint64_t off, uint64_t count) {
+      copy.resize(static_cast<size_t>(count));
+      if (count)
+        std::memcpy(copy.data(), plan.data() + off,
+                    static_cast<size_t>(count) * sizeof(UpdateInstruction));
+      return copy.data();
     };
     if (SectionInBounds(h.train_instr_offset, h.train_instr_count,
                         sizeof(UpdateInstruction), plan.size()))
-      Disassemble("train", stream(h.train_instr_offset), h.train_instr_count);
+      Disassemble("train", stream(h.train_instr_offset, h.train_instr_count),
+                  h.train_instr_count);
     if (SectionInBounds(h.eval_instr_offset, h.eval_instr_count,
                         sizeof(UpdateInstruction), plan.size()))
-      Disassemble("eval", stream(h.eval_instr_offset), h.eval_instr_count);
+      Disassemble("eval", stream(h.eval_instr_offset, h.eval_instr_count),
+                  h.eval_instr_count);
     if (SectionInBounds(h.merge_instr_offset, h.merge_instr_count,
                         sizeof(UpdateInstruction), plan.size()))
-      Disassemble("merge", stream(h.merge_instr_offset), h.merge_instr_count);
+      Disassemble("merge", stream(h.merge_instr_offset, h.merge_instr_count),
+                  h.merge_instr_count);
   }
   // The dump above is still useful forensics for a corrupt plan, but a
   // script must not need to parse text to learn the seal failed.


### PR DESCRIPTION
Fixes the code-level findings of the v1.2.4 field report and lands the GPU fine-tuning roadmap (milestone **v1.3.0 — GPU fine-tuning (Metal G1b/G1c)**, epic #59). Closes #68.

## What changed

**SMF v5 — per-op RoPE base (field-report P1).** A Llama-3 (θ=500k) / Qwen (θ=1M) / SmolLM2 (θ=100k) port previously compiled cleanly to the wrong rotation because SMF had no θ field and lowering defaulted to 10000. `attr1` (f32 bits of θ on `kRope`, 0 = 10000) is read/written for v5, checked by sema (finite, > 1), set on the SIR op, and — via the autodiff copy and lowering that already existed — lands in `kRopeFwd/Bwd out[2]`, which the validator now also checks. `export_model.py` writes v5, takes `rope_base=` on both decoder exporters and `--rope-base` on `--demo-decoder`. Readers still accept v1–v4 (attr1 = 0 → 10000), so every existing model file compiles identically.

**Bench gate fails closed (field-report P2).** `bench_compare.py` errors on zero overlapping keys instead of printing "no regression"; `--epoch-baseline` diffs against a pinned report (nightly cache key `bench-epoch-v1`, seeded once, never rolled forward) at 15% so a sub-10%/night drift cannot compound.

**P3 sweep.** Engine `arena_size` bound before `size_t` rounding; `seeml-bench` true even-count median, 64-bit overflow rejection, staged `bench.json` + cleanup on failure; `SEEML_BENCH=0` no longer enables the bench build; exporter refuses non-integral float token ids; parser `default:` diagnostic; `seeml-seeu-dump` copies streams before decoding; docs 251→345 tests.

**Roadmap.** `docs/roadmap.md` Project 5 rewritten as the v1.3.0 plan with issue numbers and the crossover-probe evidence; `SPECIFICATION.md` §7 points at it.

## Verification

- Clean `sh build/build.sh` (`-Werror`) → **350/350** tests across 25 suites (345 + 5 new: v5 round trip, parser base propagation/rejection, compiled plan carries θ on fwd and bwd, validator base rejection).
- E2E: `export_model.py --demo-decoder --rope-base 500000` → `seeml-update-compile --build` → `seeml-seeu-dump --instrs` shows `base 500000` on every `rope.fwd` and `rope.bwd` → `model_update` trains 200 steps, val loss 4.33→0.32, commits (exit 0). Default export still shows `base 10000`.
- `bench_compare.py` probes: honest pair → 0; −20% → 1; renamed keys (zero overlap) → **1** (was 0); epoch drift → 1; missing baselines → 0 with a seeding note.
- `seeml_bench.cc` compiles under `-DSEEML_STEP_TIMING -Werror`.

## Not in this PR (own issues)

`.incbin` plan embedding (#64), the loss-only update gate (#67), the CPU `GemmNT` finding (#66), and the G1b/G1c work itself (#60–#65).
