### PR TITLE
seeml-bench: report under external standards (MLX-LM, llama-bench, PaLM MFU)

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -18,6 +18,42 @@ keeps numbers comparable across commits.
 - **Per-commit trend, not absolutes.** The gate is regression against the
   previous commit's number on the same host (CI can carry the baseline as
   an artifact the way the fuzz corpus is cached).
+- **External definitions, not house units.** Every headline number is
+  reported under the definition an outside harness already prints for it
+  (next section). A metric only this repository defines cannot be set
+  beside an MLX-LM or llama.cpp log, so it cannot answer "how far behind
+  the frontier are we" — the question the whole program exists to answer.
+
+## External standards the harness reports in
+
+`seeml-bench` emits each Tier A/C cell twice: once under the internal key
+the regression gate has always compared (`rows_per_s`), and once under the
+key and definition the external tool uses. The numbers are identical by
+construction where the definitions coincide; the point is that a reader
+of an `mlx_lm.lora` log or a `llama-bench` table needs no unit translation.
+
+| field | external standard | definition here | note |
+|---|---|---|---|
+| `tokens_per_s` (token/decoder fixtures), `samples_per_s` (feature fixtures) | MLX-LM `lora` **Tokens/sec** | loss-target rows per wall second of training | MLX counts loss-masked target tokens only; every row of a SeeML batch is a target (next-token label per position), so this is exactly `rows_per_s` — the gate key is unchanged, the unit is now named |
+| `it_per_s` | MLX-LM **It/sec** | optimizer steps per second = `1000 / step_ms` | per-step, from the steps-regression slope, so lifecycle cost is excluded as MLX's warm iterations exclude it |
+| `step_ms_min` / `step_ms_max` | `llama-bench` **t/s ± σ** | spread of the per-step slope across `--repeats` | medians stay the headline; the spread says whether a delta is signal |
+| `train_loss_first` / `train_loss_last`, `trained_tokens` | MLX-LM **Train loss**, **Trained Tokens** | first/last windowed mean training loss over the whole sweep; rows trained | a sanity anchor that the timed work was real training, not a stalled loop |
+| `peak_rss_bytes`, `rss_over_planned` | MLX-LM **Peak mem**; Tier C "peak RSS vs arena" | OS-observed peak resident set (`getrusage`); ratio to `arena + plan` | process-cumulative, so it rises monotonically across fixtures; on the MB-scale fixtures the ~20 MB process floor dominates the ratio, so read it at model scale (where the field audits found 1.00–1.13×) |
+| `mfu` (only with `--peak-gflops F`) | PaLM / Megatron **model-FLOPs utilization** | achieved GEMM FLOP/s ÷ the host peak you pass | the harness never guesses a peak — a guessed denominator is not a standard. Published anchors (arXiv 2502.05317): Apple M4 GPU ≈ 2.9 TFLOP/s measured, M-series CPU AMX ≈ 1.49, NEON-only ≈ 0.84 |
+| `gemm_gflops` | (internal) | `gemm_flops_per_step / step_ms`, FLOPs summed as 2·M·N·K over the plan's own GEMM instructions | the numerator of `mfu`; kept because it needs no external input |
+| `host` | every standard's "report the machine" rule | `uname` sysname + machine | the JSON is self-describing; a number without its host string is not a benchmark |
+
+What is deliberately *not* reported: a validation perplexity. The fixtures
+train on seeded synthetic corpora, so a val loss here would be an internal
+number dressed as lm-eval output. Quality metrics against a real model
+(SmolLM-135M val loss/accuracy vs the torch reference) live in the
+validation field reports, where the corpus is real text.
+
+Reference frontier numbers for the same host class, for scale: on Apple
+M4, `mlx_lm.lora` on SmolLM-135M (bf16, r8, GPU) reports ~6.4 It/sec and
+~1,600 Tokens/sec at 1.28 GB peak; `torch.compile` on CPU reaches ~40% MFU
+against the AMX peak. SeeML's CPU path sits at 4–13% MFU on the same
+shapes — the gap the C2 SIMD and G1b Metal projects are priced against.
 
 ## Tier A — Training throughput (the headline numbers)
 
@@ -99,10 +135,14 @@ All three pieces of this program exist:
    step number), Tier A `rows_per_s`, effective GEMM GFLOP/s (the FLOPs
    are summed from the plan's own instruction stream, 2·M·N·K over every
    GEMM), the fwd/bwd/optimizer split, and the Tier D lifecycle numbers
-   (compile, load+validate, merge, checkpoint save). Medians of
-   `--repeats` (default 3); seeds and thread widths pinned. The CLI is
-   strict, like the other tools: an unknown flag or a flag that cannot
-   parse is exit 2, never a default.
+   (compile, load+validate, merge, checkpoint save), plus the
+   external-standard fields of the table above (`tokens_per_s`,
+   `it_per_s`, spread, train loss, peak RSS, and `mfu` when
+   `--peak-gflops` names the host peak). Medians of `--repeats`
+   (default 3); seeds and thread widths pinned. The CLI is strict, like
+   the other tools: an unknown flag or a flag that cannot parse is exit 2,
+   never a default. Report schema is 2; every schema-1 key is unchanged,
+   so stored baselines stay comparable.
 
 2. **The nightly `bench` CI job** restores the previous night's numbers
    from the actions cache (the fuzz-corpus trust model), runs the harness,

--- a/tool/bench_compare.py
+++ b/tool/bench_compare.py
@@ -6,6 +6,10 @@ Usage:
 
 Compares the Tier A throughput metric — rows_per_s, per fixture per thread
 width — and exits 1 if any pair regressed by more than --max-regression
+(rows_per_s is MLX-LM's "Tokens/sec" under its own definition — every row
+of a SeeML batch is a loss target — and schema-2 reports also carry it as
+tokens_per_s / samples_per_s; the gate keeps the schema-1 key so a baseline
+stored before the rename still compares)
 (default 0.10, the >10% gate of docs/benchmarks.md). A missing baseline
 file exits 0 with a note: the first run of a new host seeds the baseline
 rather than failing it. Fixtures or thread widths present on only one side

--- a/tool/seeml_bench.cc
+++ b/tool/seeml_bench.cc
@@ -3,7 +3,7 @@
 //
 //   seeml-bench --out bench.json [--threads 1,8] [--steps-lo 20]
 //               [--steps-hi 80] [--repeats 3] [--fixtures name,name,...]
-//               [--version]
+//               [--peak-gflops F] [--version]
 //
 // Compiles the standard fixture set in-process (the seeded builders the
 // test suites share), trains each plan at every requested thread width, and
@@ -15,6 +15,26 @@
 // instruction stream, and the Tier D lifecycle latencies (compile, load,
 // merge, checkpoint save).
 //
+// Alongside the internal numbers, every cell carries the fields the external
+// fine-tuning harnesses print, under their definitions, so a SeeML run can
+// be set beside an MLX-LM `lora` log or a llama-bench table without unit
+// translation:
+//   tokens_per_s / samples_per_s  MLX-LM "Tokens/sec": target rows per wall
+//                                 second (every row of a SeeML batch is a
+//                                 loss target, so this equals rows_per_s);
+//   it_per_s                      MLX-LM "It/sec" (optimizer steps per s);
+//   step_ms_min / step_ms_max     llama-bench's "± spread" over the repeats;
+//   train_loss_first / _last      MLX-LM "Train loss" (windowed means);
+//   trained_tokens                MLX-LM "Trained Tokens" over the sweep;
+//   peak_rss_bytes                MLX-LM "Peak mem" (OS-observed, process-
+//                                 cumulative, so it rises monotonically
+//                                 across fixtures);
+//   mfu                           PaLM/Megatron model-FLOPs utilization —
+//                                 achieved GEMM FLOP/s over the host peak
+//                                 given by --peak-gflops (omitted otherwise:
+//                                 a peak the harness guessed is not a
+//                                 standard).
+//
 // Everything is pinned: fixture seeds, dataset seeds, thread widths (via
 // SetParallelThreadCount, overriding SEEML_THREADS). Medians of --repeats
 // runs. Argument parsing is strict, as in seeml-update-compile: an unknown
@@ -25,10 +45,14 @@
 #include <chrono>
 #include <cinttypes>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <expected>
 #include <string>
 #include <vector>
+
+#include <sys/resource.h>
+#include <sys/utsname.h>
 
 #include "compiler/diagnostics/logger.h"
 #include "compiler/driver/update_compiler.h"
@@ -47,6 +71,25 @@ using Clock = std::chrono::steady_clock;
 
 double MsSince(Clock::time_point t0) {
   return std::chrono::duration<double, std::milli>(Clock::now() - t0).count();
+}
+
+/// OS-observed peak resident set of this process, in bytes. Linux reports
+/// ru_maxrss in kilobytes, macOS in bytes.
+uint64_t PeakRssBytes() {
+  rusage ru{};
+  if (getrusage(RUSAGE_SELF, &ru) != 0) return 0;
+#if defined(__APPLE__)
+  return static_cast<uint64_t>(ru.ru_maxrss);
+#else
+  return static_cast<uint64_t>(ru.ru_maxrss) * 1024u;
+#endif
+}
+
+/// "sysname machine" — a number without its host string is not a benchmark.
+std::string HostString() {
+  utsname u{};
+  if (uname(&u) != 0) return "unknown";
+  return std::string(u.sysname) + " " + u.machine;
 }
 
 double Median(std::vector<double> v) {
@@ -166,6 +209,17 @@ std::expected<std::vector<std::string>, std::string> SplitCsv(
   return out;
 }
 
+/// Strict positive decimal (for --peak-gflops): the whole string must parse.
+std::expected<double, std::string> ParsePositiveF64(const std::string& flag,
+                                                    const std::string& v) {
+  if (v.empty()) return std::unexpected(flag + " must be a positive number");
+  char* end = nullptr;
+  const double out = std::strtod(v.c_str(), &end);
+  if (end == v.c_str() || *end != '\0' || !(out > 0.0) || out > 1e300)
+    return std::unexpected(flag + ": '" + v + "' is not a positive number");
+  return out;
+}
+
 int Fail(const std::string& msg) {
   std::fprintf(stderr, "seeml-bench: %s\n", msg.c_str());
   return 2;
@@ -189,15 +243,17 @@ int main(int argc, char** argv) {
   auto hi_s = args.TakeValue("--steps-hi", "80");
   auto repeats_s = args.TakeValue("--repeats", "3");
   auto fixtures_csv = args.TakeValue("--fixtures", "");
+  auto peak_s = args.TakeValue("--peak-gflops", "");
   for (auto* v : {&out_path, &threads_csv, &lo_s, &hi_s, &repeats_s,
-                  &fixtures_csv})
+                  &fixtures_csv, &peak_s})
     if (!*v) return Fail(v->error());
   if (!args.rest.empty()) return Fail("unknown argument '" + args.rest[0] +
                                       "'");
   if (out_path->empty())
     return Fail("--out is required\nusage: seeml-bench --out bench.json "
                 "[--threads 1,8] [--steps-lo 20] [--steps-hi 80] "
-                "[--repeats 3] [--fixtures name,...] [--version]");
+                "[--repeats 3] [--fixtures name,...] [--peak-gflops F] "
+                "[--version]");
 
   auto lo = ParseU64("--steps-lo", *lo_s);
   auto hi = ParseU64("--steps-hi", *hi_s);
@@ -205,6 +261,13 @@ int main(int argc, char** argv) {
   for (auto* v : {&lo, &hi, &repeats})
     if (!*v) return Fail(v->error());
   if (*hi <= *lo) return Fail("--steps-hi must exceed --steps-lo");
+  // 0 = not given: mfu is then omitted rather than computed against a guess.
+  double peak_gflops = 0.0;
+  if (!peak_s->empty()) {
+    auto p = ParsePositiveF64("--peak-gflops", *peak_s);
+    if (!p) return Fail(p.error());
+    peak_gflops = *p;
+  }
 
   auto thread_names = SplitCsv("--threads", *threads_csv);
   if (!thread_names) return Fail(thread_names.error());
@@ -232,13 +295,17 @@ int main(int argc, char** argv) {
 
   FILE* out = std::fopen(out_path->c_str(), "w");
   if (!out) return Fail("cannot open '" + *out_path + "' for writing");
+  // Schema 2 adds the external-standard fields (see the header comment);
+  // every schema-1 key is unchanged, so stored baselines remain comparable.
   std::fprintf(out,
-               "{\n  \"seeml_version\": \"%s\",\n  \"schema\": 1,\n"
+               "{\n  \"seeml_version\": \"%s\",\n  \"schema\": 2,\n"
+               "  \"host\": \"%s\",\n"
                "  \"config\": {\"steps_lo\": %" PRIu64 ", \"steps_hi\": %"
-               PRIu64 ", \"repeats\": %" PRIu64 ", \"threads\": \"%s\"},\n"
+               PRIu64 ", \"repeats\": %" PRIu64 ", \"threads\": \"%s\", "
+               "\"peak_gflops\": %.1f},\n"
                "  \"fixtures\": {",
-               seeml::update::kSeemlVersion, *lo, *hi, *repeats,
-               threads_csv->c_str());
+               seeml::update::kSeemlVersion, HostString().c_str(), *lo, *hi,
+               *repeats, threads_csv->c_str(), peak_gflops);
 
   bool first_fixture = true;
   for (const Fixture* f : selected) {
@@ -267,6 +334,9 @@ int main(int argc, char** argv) {
     rt::TrainOptions quiet;
     quiet.log_every = 0;
 
+    uint64_t trainable_params = 0;
+    for (const auto& p : compiled->params) trainable_params += p.count;
+
     std::fprintf(out,
                  "%s\n    \"%s\": {\n"
                  "      \"kind\": \"%s\", \"batch_rows\": %" PRId64
@@ -275,15 +345,33 @@ int main(int argc, char** argv) {
                  ", \"persistent_bytes\": %" PRIu64 ", \"rodata_bytes\": %"
                  PRIu64 ",\n"
                  "      \"train_instructions\": %" PRIu64
-                 ", \"gemm_flops_per_step\": %" PRIu64 ",\n"
+                 ", \"gemm_flops_per_step\": %" PRIu64
+                 ", \"trainable_params\": %" PRIu64 ",\n"
                  "      \"compile_ms\": %.2f, \"load_ms\": %.3f,\n"
                  "      \"threads\": {",
                  first_fixture ? "" : ",", f->name, f->kind, f->batch_rows,
                  f->seq, compiled->plan.size(), compiled->arena_size,
                  compiled->persistent_size, compiled->rodata_size,
                  compiled->train_instruction_count,
-                 GemmFlopsPerStep(compiled->plan), compile_ms, load_ms);
+                 GemmFlopsPerStep(compiled->plan), trainable_params,
+                 compile_ms, load_ms);
     first_fixture = false;
+
+    // MLX-LM's "Train loss" / "Trained Tokens" over the whole sweep: the
+    // engine trains continuously across thread widths and repeats, so the
+    // first window is the fixture's starting loss and the last its ending
+    // loss — a sanity anchor that the timed work was real training.
+    bool have_first_loss = false;
+    float train_loss_first = 0.0f, train_loss_last = 0.0f;
+    uint64_t trained_steps = 0;
+    auto note = [&](const rt::TrainReport& r) {
+      if (!have_first_loss) {
+        train_loss_first = r.initial_avg_loss;
+        have_first_loss = true;
+      }
+      train_loss_last = r.final_avg_loss;
+      trained_steps += r.steps;
+    };
 
     bool first_thread = true;
     for (uint64_t t : threads) {
@@ -291,18 +379,22 @@ int main(int argc, char** argv) {
       // Warm the pool, the caches, and the feeder before timing.
       if (auto r = engine.Train(*data, 4, quiet); !r)
         return Fail(f->name + (": " + r.error()));
+      else
+        note(*r);
 
       std::vector<double> per_step_ms, lifecycle_ms;
       engine.ResetStepTimings();
       for (uint64_t rep = 0; rep < *repeats; ++rep) {
         const auto t_lo = Clock::now();
-        if (auto r = engine.Train(*data, *lo, quiet); !r)
-          return Fail(f->name + (": " + r.error()));
+        auto r_lo = engine.Train(*data, *lo, quiet);
         const double wall_lo = MsSince(t_lo);
+        if (!r_lo) return Fail(f->name + (": " + r_lo.error()));
+        note(*r_lo);
         const auto t_hi = Clock::now();
-        if (auto r = engine.Train(*data, *hi, quiet); !r)
-          return Fail(f->name + (": " + r.error()));
+        auto r_hi = engine.Train(*data, *hi, quiet);
         const double wall_hi = MsSince(t_hi);
+        if (!r_hi) return Fail(f->name + (": " + r_hi.error()));
+        note(*r_hi);
         const double slope = (wall_hi - wall_lo) /
                              static_cast<double>(*hi - *lo);
         per_step_ms.push_back(slope);
@@ -320,16 +412,32 @@ int main(int argc, char** argv) {
               : 0.0;
       const rt::StepTimings st = engine.step_timings();
       const double denom = st.steps ? static_cast<double>(st.steps) : 1.0;
+      // External-standard fields. Every row of a SeeML batch is a loss
+      // target (token plans: next-token label per position; feature plans:
+      // one label per row), so MLX-LM's masked "Tokens/sec" is exactly
+      // rows_per_s here; the key name says which unit the fixture trains in.
+      const char* unit_key = std::strcmp(f->kind, "feature") == 0
+                                 ? "samples_per_s"
+                                 : "tokens_per_s";
+      const double it_per_s = step_ms > 0.0 ? 1000.0 / step_ms : 0.0;
+      const auto [lo_it, hi_it] =
+          std::minmax_element(per_step_ms.begin(), per_step_ms.end());
       std::fprintf(out,
                    "%s\n        \"%" PRIu64 "\": {\"step_ms\": %.3f, "
                    "\"lifecycle_ms\": %.2f, \"rows_per_s\": %.0f, "
                    "\"gemm_gflops\": %.1f, \"fwd_ms\": %.3f, "
-                   "\"bwd_ms\": %.3f, \"opt_ms\": %.3f}",
+                   "\"bwd_ms\": %.3f, \"opt_ms\": %.3f,\n"
+                   "              \"%s\": %.0f, \"it_per_s\": %.3f, "
+                   "\"step_ms_min\": %.3f, \"step_ms_max\": %.3f",
                    first_thread ? "" : ",", t, step_ms,
                    Median(lifecycle_ms), rows_per_s, gflops,
                    1000.0 * st.fwd_seconds / denom,
                    1000.0 * st.bwd_seconds / denom,
-                   1000.0 * st.opt_seconds / denom);
+                   1000.0 * st.opt_seconds / denom, unit_key, rows_per_s,
+                   it_per_s, *lo_it, *hi_it);
+      if (peak_gflops > 0.0)
+        std::fprintf(out, ", \"mfu\": %.4f", gflops / peak_gflops);
+      std::fprintf(out, "}");
       first_thread = false;
     }
 
@@ -343,10 +451,24 @@ int main(int argc, char** argv) {
       return Fail(f->name + (": " + ok.error()));
     const double ckpt_ms = MsSince(t_ckpt);
     std::remove(ckpt.c_str());
+    // Tier C's "peak RSS vs arena" and MLX-LM's "Peak mem", measured rather
+    // than asserted: the OS-observed peak over (arena + plan).
+    const uint64_t peak_rss = PeakRssBytes();
+    const double planned = static_cast<double>(compiled->arena_size) +
+                           static_cast<double>(compiled->plan.size());
     std::fprintf(out,
                  "\n      },\n      \"merge_ms\": %.3f, "
-                 "\"checkpoint_save_ms\": %.3f\n    }",
-                 merge_ms, ckpt_ms);
+                 "\"checkpoint_save_ms\": %.3f,\n"
+                 "      \"train_loss_first\": %.6f, "
+                 "\"train_loss_last\": %.6f, \"trained_tokens\": %" PRIu64
+                 ",\n      \"peak_rss_bytes\": %" PRIu64
+                 ", \"rss_over_planned\": %.3f\n    }",
+                 merge_ms, ckpt_ms, static_cast<double>(train_loss_first),
+                 static_cast<double>(train_loss_last),
+                 trained_steps * static_cast<uint64_t>(f->batch_rows),
+                 peak_rss,
+                 planned > 0.0 ? static_cast<double>(peak_rss) / planned
+                               : 0.0);
   }
 
   std::fprintf(out, "\n  }\n}\n");


### PR DESCRIPTION
## Why

An audit of `seeml-bench` against the external fine-tuning harnesses found that every field it emitted was a house definition: `rows_per_s`, `gemm_gflops` (no peak reference, so not MFU), lifecycle ms. `docs/benchmarks.md` names tokens/s as "THE frontier comparison number against MLX / llama.cpp-finetune", but no field by that name or definition existed, and nothing MLX-LM prints per iteration (`It/sec`, `Tokens/sec`, `Trained Tokens`, `Train loss`, `Peak mem`) had a counterpart. A metric only this repo defines can't answer "how far behind the frontier are we."

## What

Schema 2 of the report. Every schema-1 key is unchanged, so the nightly gate and its cached baselines keep working (verified: `bench_compare.py` on a schema-2 report → `no Tier A regression`, exit 0).

| new field | external standard |
|---|---|
| `tokens_per_s` / `samples_per_s` | MLX-LM **Tokens/sec** — equals `rows_per_s` because every SeeML batch row is a loss target; the unit is now named per fixture kind |
| `it_per_s` | MLX-LM **It/sec** |
| `step_ms_min` / `step_ms_max` | llama-bench **± spread** across `--repeats` |
| `train_loss_first` / `train_loss_last`, `trained_tokens` | MLX-LM **Train loss** / **Trained Tokens** — proof the timed work was real training |
| `peak_rss_bytes`, `rss_over_planned` | MLX-LM **Peak mem**; Tier C's "peak RSS vs arena", measured instead of asserted |
| `mfu` (only with `--peak-gflops F`) | PaLM / Megatron model-FLOPs utilization; the harness never guesses a peak — strict parse, exit 2 on bad values |
| `trainable_params`, `host` | the "report the machine" rule; the JSON is self-describing |

Deliberately **not** added: a validation perplexity. The fixtures are seeded synthetic corpora, so a val loss would be an internal number dressed as lm-eval output. Real-model quality (SmolLM-135M vs torch reference) stays in the field reports.

`docs/benchmarks.md` gets the field-by-field mapping plus the M4 frontier anchors (MLX ~1,600 tok/s, torch.compile ~40% MFU, SeeML 4–13%); `bench_compare.py` documents why the gate key stays `rows_per_s`.

## Verified

- `SEEML_BENCH=1 sh build/build.sh` clean on Darwin arm64.
- Sample cell (`tok_v64_d64_s16` @1t, `--peak-gflops 840`): `tokens_per_s 29098, it_per_s 227.3, step_ms 4.397–4.406, mfu 0.0114`; loss 10.20 → 0.26 over 31,744 trained tokens.
- Without `--peak-gflops` the `mfu` key is absent; `--peak-gflops 0` / `12abc` → exit 2.
